### PR TITLE
Fix package name

### DIFF
--- a/src/epi-christie-projector.4Series.csproj
+++ b/src/epi-christie-projector.4Series.csproj
@@ -15,7 +15,7 @@
 		<InformationalVersion>$(Version)</InformationalVersion>
 		<OutputPath>bin\$(Configuration)\</OutputPath>
 		<Authors>PepperDash Technology</Authors>
-		<PackageId>PPepperDash.Essentials.Plugins.Christie.Projector</PackageId>
+		<PackageId>PepperDash.Essentials.Plugins.Christie.Projector</PackageId>
 		<PackageProjectUrl>https://github.com/PepperDash/epi-christie-projector</PackageProjectUrl>
 		<PackageTags>crestron 4series christie projecctor</PackageTags>
 	</PropertyGroup>


### PR DESCRIPTION
This pull request makes a minor correction to the NuGet package ID in the project file to ensure proper naming and consistency.

* Fixed the `PackageId` in `src/epi-christie-projector.4Series.csproj` by removing an extra "P" at the beginning, changing it from `PPepperDash.Essentials.Plugins.Christie.Projector` to `PepperDash.Essentials.Plugins.Christie.Projector`.