### PR TITLE
feat: implement IBasicVideoMuteWithFeedback

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,18 @@
+{
+	"version": "2.0.0",
+	"tasks": [
+		{
+			"label": "Build Christie Projector Solution",
+			"type": "shell",
+			"command": "msbuild",
+			"args": [
+				"epi-christie-projector.4Series.sln",
+				"/p:Configuration=Debug"
+			],
+			"problemMatcher": [
+				"$msCompile"
+			],
+			"group": "build"
+		}
+	]
+}

--- a/src/Christie4K25RgbController.cs
+++ b/src/Christie4K25RgbController.cs
@@ -262,6 +262,12 @@ namespace ChristieProjectorPlugin
 		{
 			if (string.IsNullOrEmpty(response)) return;
 
+			// Handle error responses
+			if (response.Contains("ERR"))
+			{
+				this.LogWarning("ProcessResponse: Device error - {response}", response);
+				return;
+			}
 
 			var responseValue = 0;
 			var responseType = "";
@@ -1028,7 +1034,8 @@ namespace ChristieProjectorPlugin
 		/// </summary>
 		public void VideoMuteGet()
 		{
-			SendText("SHU", "?");
+			// SHU command is disabled on this device
+			return;
 		}
 
 		/// <summary>
@@ -1036,11 +1043,8 @@ namespace ChristieProjectorPlugin
 		/// </summary>
 		public void VideoMuteOn()
 		{
-			SendText("SHU", 1);
-
-			Thread.Sleep(25);
-			VideoMuteGet();
-
+			// SHU command is disabled on this device
+			return;
 		}
 
 		/// <summary>
@@ -1048,10 +1052,8 @@ namespace ChristieProjectorPlugin
 		/// </summary>
 		public void VideoMuteOff()
 		{
-			SendText("SHU", 0);
-
-			Thread.Sleep(25);
-			VideoMuteGet();
+			// SHU command is disabled on this device
+			return;
 		}
 
 		/// <summary>

--- a/src/Christie4K25RgbController.cs
+++ b/src/Christie4K25RgbController.cs
@@ -262,12 +262,6 @@ namespace ChristieProjectorPlugin
 		{
 			if (string.IsNullOrEmpty(response)) return;
 
-			// Handle error responses
-			if (response.Contains("ERR"))
-			{
-				this.LogWarning("ProcessResponse: Device error - {response}", response);
-				return;
-			}
 
 			var responseValue = 0;
 			var responseType = "";
@@ -1034,8 +1028,7 @@ namespace ChristieProjectorPlugin
 		/// </summary>
 		public void VideoMuteGet()
 		{
-			// SHU command is disabled on this device
-			return;
+			SendText("SHU", "?");
 		}
 
 		/// <summary>
@@ -1043,8 +1036,11 @@ namespace ChristieProjectorPlugin
 		/// </summary>
 		public void VideoMuteOn()
 		{
-			// SHU command is disabled on this device
-			return;
+			SendText("SHU", 1);
+
+			Thread.Sleep(25);
+			VideoMuteGet();
+
 		}
 
 		/// <summary>
@@ -1052,8 +1048,10 @@ namespace ChristieProjectorPlugin
 		/// </summary>
 		public void VideoMuteOff()
 		{
-			// SHU command is disabled on this device
-			return;
+			SendText("SHU", 0);
+
+			Thread.Sleep(25);
+			VideoMuteGet();
 		}
 
 		/// <summary>

--- a/src/Christie4K25RgbController.cs
+++ b/src/Christie4K25RgbController.cs
@@ -1019,7 +1019,7 @@ namespace ChristieProjectorPlugin
 
 
 		/// <summary>
-		/// Gets or sets the feedback object for video mute state
+		/// Gets the feedback object for video mute state
 		/// </summary>
 		public BoolFeedback VideoMuteIsOn { get; private set; }
 

--- a/src/Christie4K25RgbController.cs
+++ b/src/Christie4K25RgbController.cs
@@ -21,7 +21,7 @@ namespace ChristieProjectorPlugin
 	/// input routing, power management, and video mute functionality
 	/// </summary>
 	public class Christie4K25RgbController : TwoWayDisplayBase, ICommunicationMonitor,
-		IBridgeAdvanced, IHasInputs<string>, IRoutingSinkWithSwitchingWithInputPort
+		IBridgeAdvanced, IHasInputs<string>, IRoutingSinkWithSwitchingWithInputPort, IBasicVideoMuteWithFeedback
 	{
 
 		private bool _isSerialComm;
@@ -68,7 +68,7 @@ namespace ChristieProjectorPlugin
 
 			DeviceManager.AddDevice(CommunicationMonitor);
 
-			VideoMuteIsOnFeedback = new BoolFeedback(() => VideoMuteIsOn);
+			VideoMuteIsOn = new BoolFeedback(() => _videoMuteState);
 
 			WarmupTime = props.WarmingTimeMs > 30000 ? props.WarmingTimeMs : 30000;
 			CooldownTime = props.CoolingTimeMs > 30000 ? props.CoolingTimeMs : 30000;
@@ -180,8 +180,8 @@ namespace ChristieProjectorPlugin
 			trilist.SetSigTrueAction(joinMap.VideoMuteOn.JoinNumber, VideoMuteOn);
 			trilist.SetSigTrueAction(joinMap.VideoMuteOff.JoinNumber, VideoMuteOff);
 			trilist.SetSigTrueAction(joinMap.VideoMuteToggle.JoinNumber, VideoMuteToggle);
-			VideoMuteIsOnFeedback.LinkInputSig(trilist.BooleanInput[joinMap.VideoMuteOn.JoinNumber]);
-			VideoMuteIsOnFeedback.LinkComplementInputSig(trilist.BooleanInput[joinMap.VideoMuteOff.JoinNumber]);
+			VideoMuteIsOn.LinkInputSig(trilist.BooleanInput[joinMap.VideoMuteOn.JoinNumber]);
+			VideoMuteIsOn.LinkComplementInputSig(trilist.BooleanInput[joinMap.VideoMuteOff.JoinNumber]);
 
 			// bridge online change
 			trilist.OnlineStatusChange += (sender, args) =>
@@ -315,7 +315,8 @@ namespace ChristieProjectorPlugin
 					}
 				case "SHU":
 					{
-						VideoMuteIsOn = responseValue == 1;
+						_videoMuteState = responseValue == 1;
+						VideoMuteIsOn.FireUpdate();
 						break;
 					}
 				default:
@@ -1014,31 +1015,13 @@ namespace ChristieProjectorPlugin
 
 		#region videoMute
 
-		private bool _videoMuteIsOn;
+		private bool _videoMuteState;
 
-
-		/// <summary>
-		/// Gets or sets the video mute state of the projector
-		/// </summary>
-		public bool VideoMuteIsOn
-		{
-			get { return _videoMuteIsOn; }
-			set
-			{
-				if (_videoMuteIsOn == value)
-				{
-					return;
-				}
-
-				_videoMuteIsOn = value;
-				VideoMuteIsOnFeedback.FireUpdate();
-			}
-		}
 
 		/// <summary>
 		/// Gets or sets the feedback object for video mute state
 		/// </summary>
-		public BoolFeedback VideoMuteIsOnFeedback;
+		public BoolFeedback VideoMuteIsOn { get; private set; }
 
 		/// <summary>
 		/// Polls the projector for current video mute status
@@ -1076,7 +1059,7 @@ namespace ChristieProjectorPlugin
 		/// </summary>
 		public void VideoMuteToggle()
 		{
-			if (VideoMuteIsOn)
+			if (VideoMuteIsOn.BoolValue)
 				VideoMuteOff();
 			else
 				VideoMuteOn();

--- a/src/Christie4K7HsController.cs
+++ b/src/Christie4K7HsController.cs
@@ -22,7 +22,7 @@ namespace ChristieProjectorPlugin
 	/// input routing, power management, and video mute functionality
 	/// </summary>
 	public class Christie4K7HsController : TwoWayDisplayBase, ICommunicationMonitor, IBridgeAdvanced,
-		IHasInputs<string>, IRoutingSinkWithSwitchingWithInputPort
+		IHasInputs<string>, IRoutingSinkWithSwitchingWithInputPort, IBasicVideoMuteWithFeedback
 	{
 
 		private bool _isSerialComm;
@@ -69,7 +69,7 @@ namespace ChristieProjectorPlugin
 
 			DeviceManager.AddDevice(CommunicationMonitor);
 
-			VideoMuteIsOnFeedback = new BoolFeedback(() => VideoMuteIsOn);
+			VideoMuteIsOn = new BoolFeedback(() => _videoMuteState);
 
 			WarmupTime = props.WarmingTimeMs > 30000 ? props.WarmingTimeMs : 30000;
 			CooldownTime = props.CoolingTimeMs > 30000 ? props.CoolingTimeMs : 30000;
@@ -178,8 +178,8 @@ namespace ChristieProjectorPlugin
 			trilist.SetSigTrueAction(joinMap.VideoMuteOn.JoinNumber, VideoMuteOn);
 			trilist.SetSigTrueAction(joinMap.VideoMuteOff.JoinNumber, VideoMuteOff);
 			trilist.SetSigTrueAction(joinMap.VideoMuteToggle.JoinNumber, VideoMuteToggle);
-			VideoMuteIsOnFeedback.LinkInputSig(trilist.BooleanInput[joinMap.VideoMuteOn.JoinNumber]);
-			VideoMuteIsOnFeedback.LinkComplementInputSig(trilist.BooleanInput[joinMap.VideoMuteOff.JoinNumber]);
+			VideoMuteIsOn.LinkInputSig(trilist.BooleanInput[joinMap.VideoMuteOn.JoinNumber]);
+			VideoMuteIsOn.LinkComplementInputSig(trilist.BooleanInput[joinMap.VideoMuteOff.JoinNumber]);
 
 			// bridge online change
 			trilist.OnlineStatusChange += (sender, args) =>
@@ -205,6 +205,7 @@ namespace ChristieProjectorPlugin
 				}
 
 				LampHoursFeedback.FireUpdate();
+				VideoMuteIsOn.FireUpdate();
 			};
 		}
 
@@ -303,7 +304,8 @@ namespace ChristieProjectorPlugin
 					}
 				case "SHU":
 					{
-						VideoMuteIsOn = responseValue == 1;
+						_videoMuteState = responseValue == 1;
+						VideoMuteIsOn.FireUpdate();
 						break;
 					}
 				default:
@@ -914,31 +916,13 @@ namespace ChristieProjectorPlugin
 
 		#region videoMute
 
-		private bool _videoMuteIsOn;
+		private bool _videoMuteState;
 
-
-		/// <summary>
-		/// Gets or sets the video mute state of the projector
-		/// </summary>
-		public bool VideoMuteIsOn
-		{
-			get { return _videoMuteIsOn; }
-			set
-			{
-				if (_videoMuteIsOn == value)
-				{
-					return;
-				}
-
-				_videoMuteIsOn = value;
-				VideoMuteIsOnFeedback.FireUpdate();
-			}
-		}
 
 		/// <summary>
 		/// Gets or sets the feedback object for video mute state
 		/// </summary>
-		public BoolFeedback VideoMuteIsOnFeedback;
+		public BoolFeedback VideoMuteIsOn { get; private set; }
 
 		/// <summary>
 		/// Polls the projector for current video mute status
@@ -975,7 +959,7 @@ namespace ChristieProjectorPlugin
 		/// </summary>
 		public void VideoMuteToggle()
 		{
-			if (VideoMuteIsOn)
+			if (VideoMuteIsOn.BoolValue)
 				VideoMuteOff();
 			else
 				VideoMuteOn();

--- a/src/Christie4K7HsController.cs
+++ b/src/Christie4K7HsController.cs
@@ -260,6 +260,14 @@ namespace ChristieProjectorPlugin
 		private void ProcessResponse(string response)
 		{
 			if (string.IsNullOrEmpty(response)) return;
+			
+			// Handle error responses
+			if (response.Contains("ERR"))
+			{
+				this.LogWarning("ProcessResponse: Device error - {response}", response);
+				return;
+			}
+			
 			if (!response.Contains("!")) return;
 
 			this.LogVerbose("ProcessResponse: {response}", response);
@@ -929,7 +937,8 @@ namespace ChristieProjectorPlugin
 		/// </summary>
 		public void VideoMuteGet()
 		{
-			SendText("SHU", "?");
+			// SHU command is disabled on this device
+			return;
 		}
 
 		/// <summary>
@@ -937,10 +946,8 @@ namespace ChristieProjectorPlugin
 		/// </summary>
 		public void VideoMuteOn()
 		{
-			SendText("SHU", 1);
-
-			Thread.Sleep(25);
-			VideoMuteGet();
+			// SHU command is disabled on this device
+			return;
 		}
 
 		/// <summary>
@@ -948,10 +955,8 @@ namespace ChristieProjectorPlugin
 		/// </summary>
 		public void VideoMuteOff()
 		{
-			SendText("SHU", 0);
-
-			Thread.Sleep(25);
-			VideoMuteGet();
+			// SHU command is disabled on this device
+			return;
 		}
 
 		/// <summary>

--- a/src/Christie4K7HsController.cs
+++ b/src/Christie4K7HsController.cs
@@ -260,14 +260,6 @@ namespace ChristieProjectorPlugin
 		private void ProcessResponse(string response)
 		{
 			if (string.IsNullOrEmpty(response)) return;
-			
-			// Handle error responses
-			if (response.Contains("ERR"))
-			{
-				this.LogWarning("ProcessResponse: Device error - {response}", response);
-				return;
-			}
-			
 			if (!response.Contains("!")) return;
 
 			this.LogVerbose("ProcessResponse: {response}", response);
@@ -937,8 +929,7 @@ namespace ChristieProjectorPlugin
 		/// </summary>
 		public void VideoMuteGet()
 		{
-			// SHU command is disabled on this device
-			return;
+			SendText("SHU", "?");
 		}
 
 		/// <summary>
@@ -946,8 +937,10 @@ namespace ChristieProjectorPlugin
 		/// </summary>
 		public void VideoMuteOn()
 		{
-			// SHU command is disabled on this device
-			return;
+			SendText("SHU", 1);
+
+			Thread.Sleep(25);
+			VideoMuteGet();
 		}
 
 		/// <summary>
@@ -955,8 +948,10 @@ namespace ChristieProjectorPlugin
 		/// </summary>
 		public void VideoMuteOff()
 		{
-			// SHU command is disabled on this device
-			return;
+			SendText("SHU", 0);
+
+			Thread.Sleep(25);
+			VideoMuteGet();
 		}
 
 		/// <summary>

--- a/src/Christie4K7HsController.cs
+++ b/src/Christie4K7HsController.cs
@@ -920,7 +920,7 @@ namespace ChristieProjectorPlugin
 
 
 		/// <summary>
-		/// Gets or sets the feedback object for video mute state
+		/// Gets the feedback object for video mute state
 		/// </summary>
 		public BoolFeedback VideoMuteIsOn { get; private set; }
 


### PR DESCRIPTION
This pull request refactors the video mute feedback mechanism for both the `Christie4K25RgbController` and `Christie4K7HsController` classes to improve consistency and reliability. The changes standardize the use of the `BoolFeedback` class for video mute state, replace direct boolean properties with feedback objects, and update the API linkage accordingly. Additionally, a VSCode build task is introduced for easier project builds.

**Refactoring and Standardization of Video Mute Feedback:**

* Replaced the `VideoMuteIsOn` boolean property and its associated feedback object (`VideoMuteIsOnFeedback`) with a single `BoolFeedback` property called `VideoMuteIsOn` in both `Christie4K25RgbController` and `Christie4K7HsController`. This property now encapsulates the mute state and provides feedback updates. [[1]](diffhunk://#diff-433fed0e5fcd06056929bd6538e8a9079fe636c4f278644e53487391b0913568L1017-R1024) [[2]](diffhunk://#diff-ca82a5a113d819ee3ee93656bee9e181dd64a9529cf27f6f22be387532acbea3L917-R925)
* Updated the implementation to use a private `_videoMuteState` field, with the `BoolFeedback` object referencing this field for its value. [[1]](diffhunk://#diff-433fed0e5fcd06056929bd6538e8a9079fe636c4f278644e53487391b0913568L1017-R1024) [[2]](diffhunk://#diff-ca82a5a113d819ee3ee93656bee9e181dd64a9529cf27f6f22be387532acbea3L917-R925)
* Modified the `ProcessResponse` method to set `_videoMuteState` and explicitly call `VideoMuteIsOn.FireUpdate()` when the mute state changes, ensuring feedback is always current. [[1]](diffhunk://#diff-433fed0e5fcd06056929bd6538e8a9079fe636c4f278644e53487391b0913568L318-R319) [[2]](diffhunk://#diff-ca82a5a113d819ee3ee93656bee9e181dd64a9529cf27f6f22be387532acbea3L306-R308)
* Changed the `VideoMuteToggle` method to use `VideoMuteIsOn.BoolValue` instead of the previous boolean property, aligning with the new feedback approach. [[1]](diffhunk://#diff-433fed0e5fcd06056929bd6538e8a9079fe636c4f278644e53487391b0913568L1079-R1062) [[2]](diffhunk://#diff-ca82a5a113d819ee3ee93656bee9e181dd64a9529cf27f6f22be387532acbea3L978-R962)

**API and Interface Updates:**

* Updated the `LinkToApi` method in both controllers to link the new `VideoMuteIsOn` feedback property to the appropriate API signals, replacing the old feedback linkage. [[1]](diffhunk://#diff-433fed0e5fcd06056929bd6538e8a9079fe636c4f278644e53487391b0913568L183-R184) [[2]](diffhunk://#diff-ca82a5a113d819ee3ee93656bee9e181dd64a9529cf27f6f22be387532acbea3L181-R182)
* Added the `IBasicVideoMuteWithFeedback` interface to both controller classes, clarifying their support for video mute feedback. [[1]](diffhunk://#diff-433fed0e5fcd06056929bd6538e8a9079fe636c4f278644e53487391b0913568L24-R24) [[2]](diffhunk://#diff-ca82a5a113d819ee3ee93656bee9e181dd64a9529cf27f6f22be387532acbea3L25-R25)
* Ensured feedback is fired on API online status changes for video mute state in the 4K7Hs controller.

**Development Environment:**

* Added a VSCode build task (`.vscode/tasks.json`) to simplify building the Christie Projector solution from within the editor.