### PR TITLE
Feature/command queue

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,18 @@
+{
+	"version": "2.0.0",
+	"tasks": [
+		{
+			"label": "Build Christie Projector Solution",
+			"type": "shell",
+			"command": "msbuild",
+			"args": [
+				"epi-christie-projector.4Series.sln",
+				"/p:Configuration=Debug"
+			],
+			"problemMatcher": [
+				"$msCompile"
+			],
+			"group": "build"
+		}
+	]
+}

--- a/README.md
+++ b/README.md
@@ -652,7 +652,7 @@ Christie4K7HsController / Christie4K25RgbController
 
 ---
 
-**Generated:** January 28, 2026  
+**Generated:** January  28, 2026  
 **Framework Version:** PepperDash Essentials 2.5.1+  
 **Plugin Version:** 1.0.0  
 **Methodology:** SOURCE-FIRST EXTRACTION per COPILOT_README_PROMPTS.md

--- a/README.md
+++ b/README.md
@@ -1,107 +1,658 @@
-![PepperDash Essentials Pluign Logo](/images/essentials-plugin-blue.png)
+# Crestron Christie Projector Plugin - Configuration Guide
 
-# PepperDash Christie Projector Plugin (c) 2024
+Comprehensive power management, input control, and video mute functionality for Christie 4K25-RGB and 4K7-HS projectors. Integrates with Crestron Essentials for intelligent device-response-driven state management, real-time feedback, and safe power cycling with automatic warm-up and cool-down sequences.
 
-## Device Configuration
+---
 
-```json
-{
-	"key": "projector1",
-	"uid": 1,
-	"name": "Christie 4K7-HS Projector",
-	"type": "christie4K7HsProjector",
-	"group": "plugin",
-	"properties": {
-		"control": {
-			"method": "tcpIp",
-			"tcpSshProperties": {
-				"address": "",
-				"port": 3002,
-				"username": "",
-				"password": "",
-				"autoReconnect": true,
-				"autoReconnectIntervalMs": 5000,
-			},
-			"pollIntervalMs": 60000,
-			"coolingTimeMs": 30000,
-			"warmingTimeMs": 30000,
-			"hasLamps": true,
-			"hasScreen": false,
-			"hasLift": false
-		}
-	}
-}
+<!-- START Minimum Essentials Framework Versions -->
+### Minimum Essentials Framework Versions
 
-{
-	"key": "projector2",
-	"uid": 1,
-	"name": "Christie 4K25-RGB Projector",
-	"type": "christie4K25RgbProjector",
-	"group": "plugin",
-	"properties": {
-		"control": {
-			"method": "tcpIp",
-			"tcpSshProperties": {
-				"address": "",
-				"port": 3002,
-				"username": "",
-				"password": "",
-				"autoReconnect": true,
-				"autoReconnectIntervalMs": 5000,
-			},
-			"pollIntervalMs": 60000,
-			"coolingTimeMs": 30000,
-			"warmingTimeMs": 30000,
-			"hasLamps": true,
-			"hasScreen": false,
-			"hasLift": false
-		}
-	}
-}
-```
-**Notes**
+- 2.5.1 (PepperDash Essentials)
+<!-- END Minimum Essentials Framework Versions -->
 
-`hasLamps`, `hasScreen`, `hasLift` are configuration options that are exposed via the bridge and can be leveraged by the developer in SIMPL.
+---
 
-## Bridge Configuration
+<!-- START IMPORTANT -->
+### ⚠️ IMPORTANT: Device-Response-Driven State Management
+
+**Critical Power Management Behavior:**
+
+The Christie projector plugin uses device feedback responses to manage power state transitions. The device returns specific response values that indicate its operational state:
+- **PWR!00** = Power OFF (confirmed)
+- **PWR!01** = Power ON (confirmed, fully warmed)
+- **PWR!10** = Cooling Down (transition state - device is actively cooling)
+- **PWR!11** = Warming Up (transition state - device is actively warming)
+
+**Safety Features:**
+- Minimum 25-second warm-up and cool-down periods are enforced (configurable, cannot be reduced below 25 seconds)
+- Power commands sent during opposite state transitions are automatically queued and executed after the current transition completes
+- Do NOT attempt to power on while device is warming, or power off while cooling - the plugin handles this automatically
+- Device responses drive all state flags, not timers alone. Timers serve as safety fallbacks only.
+
+**Example Safe Scenario:**
+User presses PowerOn → Device responds PWR!11 (warming) → User immediately presses PowerOff → PowerOff queued automatically → Device responds PWR!01 (warmup complete) → Pending PowerOff automatically executes → Device responds PWR!10 (cooling) → Device responds PWR!00 (cooldown complete)
+
+<!-- END IMPORTANT -->
+
+---
+
+<!-- START Supported Types -->
+### Supported Types
+
+**Device Types:**
+- `christie4k7hsprojector` - Christie 4K7-HS Projector
+- `christie4k25rgbprojector` - Christie 4K25-RGB Projector
+
+Both devices support identical communication methods (RS-232 serial and TCP/Network) and feature sets.
+
+<!-- END Supported Types -->
+
+---
+
+<!-- START Config Example -->
+### Config Examples
+
+#### TCP Configuration (Network)
 
 ```json
 {
-	"key": "plugin-bridge1",
-	"uid": 3,
-	"name": "Plugin Bridge",
-	"group": "api",
-	"type": "eiscApiAdvanced",
-	"properties": {
-		"control": {
-			"tcpSshProperties": {
-				"address": "127.0.0.2",
-				"port": 0
-			},
-			"ipid": "B2",
-			"method": "ipidTcp"
-		},
-		"devices": [
-			{
-				"deviceKey": "projector1",
-				"joinStart": 1
-			}
-		]
-	}
+  "key": "roomA-projector",
+  "uid": 1,
+  "name": "Room A Christie 4K7-HS",
+  "type": "christie4k7hsprojector",
+  "group": "displays",
+  "properties": {
+    "control": {
+      "method": "tcpIp",
+      "tcpSshProperties": {
+        "address": "192.168.1.100",
+        "port": 3002,
+        "username": "",
+        "password": "",
+        "autoReconnect": true,
+        "autoReconnectIntervalMs": 5000
+      }
+    },
+    "pollIntervalMs": 10000,
+    "warmingTimeMs": 25000,
+    "coolingTimeMs": 25000,
+    "hasLamps": true,
+    "hasScreen": false,
+    "hasLift": false
+  }
 }
 ```
+**Note:** Standard TCP/Network configuration for Christie projectors. Device IP address must be static. Port 3002 is the standard Christie serial-over-IP port. Poll interval minimum enforced at 10 seconds.
 
-## Bridge Map
+#### RS-232 Serial Configuration
 
-### Digitals
+```json
+{
+  "key": "conferenceRoom-projector",
+  "uid": 2,
+  "name": "Conference Christie 4K25-RGB",
+  "type": "christie4k25rgbprojector",
+  "group": "displays",
+  "properties": {
+    "control": {
+      "method": "com",
+      "controlPortNumber": 1,
+      "comParams": {
+        "baudRate": 9600,
+        "dataBits": 8,
+        "stopBits": 1,
+        "parity": "None",
+        "softwareHandshake": "None",
+        "hardwareHandshake": "None",
+        "protocol": "RS232"
+      }
+    },
+    "pollIntervalMs": 10000,
+    "warmingTimeMs": 25000,
+    "coolingTimeMs": 25000,
+    "hasLamps": true,
+    "hasScreen": false,
+    "hasLift": false
+  }
+}
+```
+**Note:** RS-232 serial configuration. Device connects to control processor serial port (typically 1-3 for CP4). Communication at 9600 baud, 8 data bits, no parity, 1 stop bit (device firmware fixed).
 
+#### Multi-Device Configuration (Mixed)
 
+```json
+[
+  {
+    "key": "main-display",
+    "uid": 10,
+    "name": "Main Room Projector",
+    "type": "christie4k7hsprojector",
+    "group": "displays",
+    "properties": {
+      "control": {
+        "method": "tcpIp",
+        "tcpSshProperties": {
+          "address": "192.168.1.100",
+          "port": 3002,
+          "username": "",
+          "password": "",
+          "autoReconnect": true,
+          "autoReconnectIntervalMs": 5000
+        }
+      },
+      "pollIntervalMs": 10000,
+      "warmingTimeMs": 25000,
+      "coolingTimeMs": 25000,
+      "hasLamps": true,
+      "hasScreen": false,
+      "hasLift": false
+    }
+  },
+  {
+    "key": "backup-display",
+    "uid": 11,
+    "name": "Backup Room Projector",
+    "type": "christie4k25rgbprojector",
+    "group": "displays",
+    "properties": {
+      "control": {
+        "method": "com",
+        "controlPortNumber": 2,
+        "comParams": {
+          "baudRate": 9600,
+          "dataBits": 8,
+          "stopBits": 1,
+          "parity": "None",
+          "softwareHandshake": "None",
+          "hardwareHandshake": "None",
+          "protocol": "RS232"
+        }
+      },
+      "pollIntervalMs": 10000,
+      "warmingTimeMs": 25000,
+      "coolingTimeMs": 25000,
+      "hasLamps": true,
+      "hasScreen": false,
+      "hasLift": false
+    }
+  }
+]
+```
+**Note:** Multi-device configuration with mixed communication methods (TCP for main, serial for backup). UIDs must be unique across all devices.
 
-### Analogs
+<!-- END Config Example -->
 
+---
 
+<!-- START Device Series Capabilities -->
+### Device Series Capabilities
 
-### Serials
+| Feature | 4K7-HS | 4K25-RGB | Notes |
+|---------|--------|----------|-------|
+| Power On/Off | ✓ | ✓ | Managed with 25-second warm-up/cool-down |
+| Input Selection | ✓ | ✓ | HDMI, DigitalLink, and other inputs |
+| Video Mute | ✓ | ✓ | Blanks display output (SHU command) |
+| Power States | ✓ | ✓ | OFF, Warming, Fully On, Cooling |
+| Lamp Hours | ✓ | ✓ | Feedback-only, not adjustable |
+| Communication | TCP/Serial | TCP/Serial | RS-232 at 9600 baud or TCP port 3002 |
+| Polling | 10s minimum | 10s minimum | Configurable, enforced minimum |
+| Feedback Responses | PWR, SIN, SHU, ILI | PWR, SIN, SHU, ILI | Four primary device response types |
 
+<!-- END Device Series Capabilities -->
 
+---
 
+<!-- START Core Properties -->
+### Core Properties
+
+| Property | Type | Required | Default | Description |
+|----------|------|----------|---------|-------------|
+| `key` | string | ✓ | - | Unique device identifier |
+| `uid` | integer | ✓ | - | Essentials system UID (must be unique) |
+| `name` | string | ✓ | - | Device display name |
+| `type` | string | ✓ | - | Device type (`christie4k7hsprojector` or `christie4k25rgbprojector`) |
+| `group` | string | ✓ | - | Device grouping (e.g., `"displays"`, `"projectors"`) |
+| `control` | object | ✓ | - | Communication control configuration (TCP or Serial) |
+| `pollIntervalMs` | long | ✗ | 10000 | Status poll interval in milliseconds (minimum 10000) |
+| `warmingTimeMs` | long | ✗ | 25000 | Device warm-up period in milliseconds (minimum 25000) |
+| `coolingTimeMs` | long | ✗ | 25000 | Device cool-down period in milliseconds (minimum 25000) |
+| `hasLamps` | bool | ✗ | false | Device has lamp indicator for feedback purposes |
+| `hasScreen` | bool | ✗ | false | Device has screen for feedback purposes |
+| `hasLift` | bool | ✗ | false | Device has motorized lift for feedback purposes |
+
+<!-- END Core Properties -->
+
+---
+
+### Property Details
+
+**Core Configuration:**
+
+- **`key`:** Unique device identifier within the system. Used for device reference in routing and control logic. Examples: `"roomA-projector"`, `"main-display"`, `"backup-display"`.
+
+- **`uid`:** Essentials system UID. Must be unique across all devices in the system. Critical for device communication and feedback routing. Range: 1-65535. Example: `1`, `10`, `100`.
+
+- **`name`:** Device name displayed in the control system UI and used internally. Should be descriptive (e.g., `"Room A Christie 4K7-HS"`, `"Main Conference Projector"`).
+
+- **`type`:** Device type identifier. Must be one of:
+  - `"christie4k7hsprojector"` for Christie 4K7-HS models
+  - `"christie4k25rgbprojector"` for Christie 4K25-RGB models
+
+- **`group`:** Logical grouping category for device organization. Recommended values: `"displays"`, `"projectors"`, `"presentation"`.
+
+**Communication Configuration:**
+
+- **`control.method`:** Communication method type:
+  - `"tcpIp"` for TCP/Network connection to device
+  - `"com"` for RS-232 serial connection
+
+- **`control.tcpSshProperties`:** (TCP only) Network communication settings:
+  - `"address"`: Device IP address (must be static)
+  - `"port"`: Device port (typically 3002 for Christie serial-over-IP)
+
+- **`control.controlPortNumber`:** (Serial only) Control processor's serial port number:
+  - Typical range: 1-3 for CP4
+  - Verify with system configuration for your processor
+
+- **`control.comParams`:** (Serial only) Serial communication parameters (all values fixed for Christie devices):
+  - `"baudRate"`: Must be `9600` (device firmware fixed)
+  - `"dataBits"`: Must be `8`
+  - `"stopBits"`: Must be `1`
+  - `"parity"`: Must be `"None"`
+  - `"softwareHandshake"`: Must be `"None"`
+  - `"hardwareHandshake"`: Must be `"None"`
+  - `"protocol"`: Must be `"RS232"`
+
+**Monitoring & Timing:**
+
+- **`pollIntervalMs`:** How often (in milliseconds) the system queries device status.
+  - **Minimum enforced:** 10000 ms (10 seconds)
+  - **Recommended:** 10000 ms for normal operation
+  - **Lower is more responsive but consumes more bandwidth**
+  - Values below 10000 ms will be forced to 10000 ms by the plugin
+
+- **`warmingTimeMs`:** Duration (in milliseconds) to wait for device to complete power-on warm-up cycle.
+  - **Minimum enforced:** 25000 ms (25 seconds)
+  - **Must match actual device warm-up time:** Real Christie projectors require ~25 seconds to fully warm up
+  - **Recommended:** 25000 ms (do not increase unless device specifically requires longer)
+  - **Safety:** Commands cannot be sent to device during warm-up period
+  - Values below 25000 ms will be forced to 25000 ms by the plugin
+
+- **`coolingTimeMs`:** Duration (in milliseconds) to wait for device to complete power-off cool-down cycle.
+  - **Minimum enforced:** 25000 ms (25 seconds)
+  - **Must match actual device cool-down time:** Real Christie projectors require ~25 seconds to fully cool down
+  - **Recommended:** 25000 ms (do not increase unless device specifically requires longer)
+  - **Safety:** Commands cannot be sent to device during cool-down period
+  - Values below 25000 ms will be forced to 25000 ms by the plugin
+
+**Device Capabilities:**
+
+- **`hasLamps`:** Boolean indicating whether the device has lamp indicators. Used for bridge feedback purposes (true if device reports lamp hours).
+
+- **`hasScreen`:** Boolean indicating whether the device has a screen. Used for bridge feedback purposes.
+
+- **`hasLift`:** Boolean indicating whether the device has a motorized lift. Used for bridge feedback purposes.
+
+---
+
+<!-- START Join Maps -->
+### Join Maps
+
+#### Digitals
+
+| Join | Direction | Description |
+|------|-----------|-------------|
+| 1 | R | Is Online (Communication Status) |
+| 2 | R/W | Power On / Power On Feedback |
+| 3 | R/W | Power Off / Power Off Feedback |
+| 4 | R | Power Toggle |
+| 5 | R | Is Warming Up Feedback |
+| 6 | R | Is Cooling Down Feedback |
+| 11 | R/W | Input HDMI 1 Select / Feedback |
+| 12 | R/W | Input HDMI 2 Select / Feedback |
+| 13 | R/W | Input DigitalLink Select / Feedback |
+| 14 | R/W | Input DVI-D Select / Feedback |
+| 15 | R/W | Input DisplayPort Select / Feedback |
+| 16 | R/W | Input SDI 1 Select / Feedback |
+| 17 | R/W | Input SDI 2 Select / Feedback |
+| 18 | R/W | Input SDI 3 Select / Feedback |
+| 19 | R/W | Input SDI 4 Select / Feedback |
+| 20 | R/W | Input USB Select / Feedback |
+| 21 | R/W | Input Network Select / Feedback |
+| 31 | R | Has Lamps (Device Capability Feedback) |
+| 32 | R | Has Screen (Device Capability Feedback) |
+| 33 | R | Has Lift (Device Capability Feedback) |
+| 51 | R/W | Video Mute On / Video Mute On Feedback |
+| 52 | R/W | Video Mute Off / Video Mute Off Feedback |
+| 53 | R/W | Video Mute Toggle / Video Mute State |
+
+#### Analogs
+
+| Join | Direction | Description |
+|------|-----------|-------------|
+| 1 | R | Communication Status (0=Online, 1=Warning, 2=Error) |
+| 2 | R | Current Input Selection (1-11 for input number) |
+| 3 | R | Lamp Hours (Read-only feedback) |
+| 4 | W | Input Select Command (1-11 to switch input) |
+
+#### Serials
+
+| Join | Direction | Description |
+|------|-----------|-------------|
+| 1 | R | Device Name |
+| 2 | R | Current Input Name (String feedback) |
+
+<!-- END Join Maps -->
+
+---
+
+### Join Details
+
+**Communication & Status:**
+
+- **1 (Is Online):** Device online status feedback. True = device is responding and communication is healthy. False = device offline or communication failure detected.
+
+- **Communication Status (Analog 1):** Numeric communication status: 0 = Online (healthy), 1 = Warning (degraded), 2 = Error (offline).
+
+**Power Control:**
+
+- **2 (Power On):** Power on control and feedback. Write high to trigger power-on sequence. Reads true when device is powered on or warming up.
+
+- **3 (Power Off):** Power off control and feedback. Write high to trigger power-off sequence. Reads true when device is powered off or cooling down.
+
+- **4 (Power Toggle):** Bidirectional power toggle. Write high to toggle current power state.
+
+- **5 (Is Warming Up):** Read-only feedback. True when device is in warm-up sequence (PWR!11 response received). Use to display "Warming..." indicator in UI.
+
+- **6 (Is Cooling Down):** Read-only feedback. True when device is in cool-down sequence (PWR!10 response received). Use to display "Cooling..." indicator in UI.
+
+**Input Selection:**
+
+- **11-21 (Input Select):** Digital joins for each input type (HDMI1, HDMI2, DigitalLink, DVI-D, DisplayPort, SDI 1-4, USB, Network). Write high to select input. Reads true when that input is currently active.
+
+- **Analog 2 (Current Input):** Numeric input selection feedback. Values 1-11 corresponding to each input type.
+
+- **Analog 4 (Input Select Command):** Write analog value 1-11 to switch input via analog command.
+
+- **Serial 2 (Input Name):** String feedback showing current input name (e.g., "HDMI 1", "DigitalLink").
+
+**Device Capabilities:**
+
+- **31 (Has Lamps):** Device capability feedback. True if device reports lamp hour capability.
+
+- **32 (Has Screen):** Device capability feedback. True if device has motorized screen.
+
+- **33 (Has Lift):** Device capability feedback. True if device has motorized lift.
+
+- **Analog 3 (Lamp Hours):** Read-only numeric feedback displaying cumulative lamp operating hours.
+
+**Video Mute:**
+
+- **51 (Video Mute On):** Video mute control and feedback. Write high to blank display. Reads true when mute is active.
+
+- **52 (Video Mute Off):** Video mute off control and feedback. Write high to show display. Reads true when video is visible.
+
+- **53 (Video Mute Toggle):** Toggle video mute state. Write high to switch between mute on/off.
+
+**Device Information:**
+
+- **Serial 1 (Device Name):** String feedback with configured device name (from config file).
+
+---
+
+<!-- START Interfaces Implemented -->
+### Interfaces Implemented
+
+- `ITwoWayDisplayWithAudio` - Two-way display control interface (base for all power/input/mute methods)
+- `IOnline` - Online status feedback interface
+- `ICommunicationMonitor` - Communication monitoring and error detection
+- `IBridgeAdvanced` - Advanced bridge support for EISC API integration
+
+<!-- END Interfaces Implemented -->
+
+---
+
+<!-- START Base Classes -->
+### Base Classes
+
+**Device Base Classes:**
+- `TwoWayDisplayBase` - Base class for two-way display devices with power, input, and mute control
+
+**Communication & Monitoring:**
+- `CommunicationGather` - Serial message gathering and parsing (accumulates data until delimiter found)
+- `GenericCommunicationMonitor` - Communication health monitoring with online/offline/error state tracking
+- `IBasicCommunication` - Core communication interface abstraction
+
+**Bridge & Join Mapping:**
+- `DisplayControllerJoinMap` - Base join map for display control devices
+- `ChristieProjectorBridgeJoinMap` - Christie-specific join map extending DisplayControllerJoinMap
+
+**Device Management:**
+- `DeviceManager` - Essentials device registry and lifecycle management
+- `EssentialsPluginDeviceFactory<T>` - Base factory for creating plugin devices
+
+<!-- END Base Classes -->
+
+---
+
+<!-- START Routing Framework -->
+### Routing Framework & Architecture
+
+**State Management Architecture:**
+
+The Christie projector plugin implements a device-response-driven state machine that prioritizes actual device feedback over timer-based assumptions.
+
+**Power State Flow:**
+
+```
+User Action
+    ↓
+PowerOn()/PowerOff() method
+    ├─ Check current state flags
+    ├─ Apply guards (skip duplicate, queue conflicting)
+    └─ Send command to device
+         ↓
+Device responds with PWR!xx
+    ↓
+ProcessResponse() receives value
+    ├─ PWR!11 (Warming): Set IsWarmingUp=true
+    ├─ PWR!10 (Cooling): Set IsCoolingDown=true
+    ├─ PWR!01 (ON confirmed): Clear IsWarmingUp, execute pending PowerOff if queued
+    └─ PWR!00 (OFF confirmed): Clear IsCoolingDown, execute pending PowerOn if queued
+         ↓
+Timers act as safety fallback (25s expiry)
+```
+
+**Command Queuing:**
+
+- All control commands (PWR, SIN, SHU) are queued in `_commandQueue` (generic Queue<string>)
+- Query commands (PWR?, SIN?, SHU?) bypass queue and execute immediately
+- Queue processes with 100ms minimum send interval to prevent device overload
+- No queue blocking on state flags - conflicting commands are handled by PowerOn/PowerOff guard clauses
+
+**Guard Clause Logic:**
+
+| Method | Current State | Action |
+|--------|---------------|--------|
+| PowerOn() | IsWarmingUp=true | Return (skip) - already warming |
+| PowerOn() | IsCoolingDown=true | Set _pendingPowerOn=true, return (queue) |
+| PowerOn() | Idle | Send (PWR1), set IsWarmingUp=true |
+| PowerOff() | IsCoolingDown=true | Return (skip) - already cooling |
+| PowerOff() | IsWarmingUp=true | Set _pendingPowerOff=true, return (queue) |
+| PowerOff() | Idle | Send (PWR0), set IsCoolingDown=true |
+
+**Pending Command Execution:**
+
+When device reaches confirmed state:
+- If `_pendingPowerOn=true` after PWR!00: Automatically call PowerOn()
+- If `_pendingPowerOff=true` after PWR!01: Automatically call PowerOff()
+- Prevents manual queuing by developer - happens automatically in ProcessResponse()
+
+**Communication Protocol:**
+
+- **Outbound:** Commands in format `(CMD)` or `(CMD n)` (e.g., `(PWR1)`, `(SIN11)`)
+- **Inbound:** Responses in format `(CMD!nn)` (e.g., `(PWR!01)`, `(SIN!04)`)
+- **Delimiter:** Line feed (`\n`) terminates responses for parsing
+- **Polling:** StatusGet() sends `(PWR?)`, `(SIN?)`, `(SHU?)` queries on configured interval
+
+**Response Value Meanings:**
+
+- PWR: 0=OFF, 1=ON (fully warmed), 10=Cooling Down, 11=Warming Up
+- SIN: 1-11 (input selection)
+- SHU: 0=Video On, 1=Video Mute
+- ILI: Lamp hours (numeric, read-only)
+
+<!-- END Routing Framework -->
+
+---
+
+<!-- START Configuration Best Practices -->
+### Configuration Best Practices
+
+**Communication Setup:**
+
+- **TCP Configuration:**
+  - Verify device IP address is static and accessible from control processor
+  - Confirm port 3002 is open and device is listening
+  - Test connectivity with ping before deploying config: `ping 192.168.x.x`
+  - Document IP address and port for maintenance
+
+- **Serial Configuration:**
+  - Identify correct COM port on control processor (typically 1-3 for CP4)
+  - Verify COM port is available (not in use by other devices)
+  - Serial parameters are fixed by device firmware (9600 baud, 8N1)
+  - Test connectivity using terminal utility before final deployment
+  - Use serial port labels that match physical control processor ports
+
+**Device Configuration:**
+
+- Use unique, descriptive device keys: `"roomA-projector"`, `"main-display"`, NOT `"proj1"` or `"display"`
+- Assign UIDs sequentially for easy reference: 1, 2, 3 or 10, 11, 12 (avoid random numbers)
+- Group devices logically: `"displays"`, `"projectors"`, `"presentation-equipment"`
+- Set `hasLamps`, `hasScreen`, `hasLift` to match actual device capabilities (for accurate feedback)
+
+**Timing Configuration:**
+
+- **Warming Time:** Must be ≥ 25000 ms to allow device full warm-up cycle
+- **Cooling Time:** Must be ≥ 25000 ms to allow device full cool-down cycle
+- **Poll Interval:** Minimum 10000 ms; higher intervals reduce network traffic but increase feedback latency
+- **Never modify minimum values** - they are enforced by device firmware and safety requirements
+
+**Production Deployment Checklist:**
+
+- [ ] Device IP address is static (for TCP) or COM port is correct (for serial)
+- [ ] Device is powered on and accessible before starting Essentials
+- [ ] Configuration UIDs are unique across all devices
+- [ ] Warming and cooling times set to minimum 25000 ms
+- [ ] Poll interval configured (default 10000 ms is recommended)
+- [ ] Test power on: Should see PWR!11 (warming), then PWR!01 (on)
+- [ ] Test power off: Should see PWR!10 (cooling), then PWR!00 (off)
+- [ ] Test input selection: Should see SIN response with correct value
+- [ ] Test video mute: Should see SHU response changing between 0 and 1
+- [ ] Verify online status feedback transitions to "Online" after 10-15 seconds
+- [ ] Check lamp hours feedback displays current value (if applicable)
+
+**Common Pitfalls to Avoid:**
+
+- ❌ Setting warm/cool times below 25000 ms (will be forced up by plugin)
+- ❌ Using dynamic IP addresses for TCP connections (must be static)
+- ❌ Duplicate UIDs across devices (causes device identification conflicts)
+- ❌ Sending power commands more frequently than 100 ms (queue throttling prevents damage)
+- ❌ Assuming immediate power transitions (device responds with transition states 11 and 10)
+- ❌ Ignoring IsWarmingUp/IsCoolingDown feedback in UI (should display "Warming..." / "Cooling...")
+
+<!-- END Configuration Best Practices -->
+
+---
+
+### Bool Feedbacks
+
+- `PowerIsOn` - Device power on state (true when fully powered on)
+- `IsWarmingUp` - Device warming up state (true during PWR!11 transition)
+- `IsCoolingDown` - Device cooling down state (true during PWR!10 transition)
+- `IsOnline` - Device online/communication status
+- `VideoMuteIsOn` - Video mute state (true when display is blanked)
+- `HasLamps` - Device has lamp indicator capability
+- `HasScreen` - Device has screen capability
+- `HasLift` - Device has lift capability
+
+---
+
+### Int Feedbacks
+
+- `CommunicationMonitor.Status` - Communication status (0=Online, 1=Warning, 2=Error)
+- `CurrentInputNumber` - Current input selection (1-11)
+- `LampHours` - Lamp operating hours (read-only)
+
+---
+
+### String Feedbacks
+
+- `Name` - Device name
+- `CurrentInput` - Current input name string (e.g., "HDMI 1", "DigitalLink")
+
+---
+
+### Public Methods
+
+**Power Control:**
+- `PowerOn()` - Initiate power-on sequence (handles warm-up automatically)
+- `PowerOff()` - Initiate power-off sequence (handles cool-down automatically)
+- `PowerToggle()` - Toggle between on and off states
+
+**Input Selection:**
+- `SetInput(uint input)` - Select input by number (1-11)
+- `InputHdmi1()` through `InputDigitalLink2()` - Select specific input by method
+
+**Video Mute:**
+- `VideoMuteOn()` - Blank display output
+- `VideoMuteOff()` - Show display output
+- `VideoMuteToggle()` - Toggle video mute state
+
+**Status & Polling:**
+- `PowerGet()` - Poll current power status (sends PWR? query)
+- `StatusGet()` - Poll all device status (powers, input, mute, lamp hours)
+- `VideoMuteGet()` - Poll video mute status (sends SHU? query)
+
+**Bridge Integration:**
+- `LinkToApi(BasicTriList trilist, uint joinStart, string joinMapKey, EiscApiAdvanced bridge)` - Link device to EISC API bridge
+
+---
+
+### Architecture Overview
+
+**Core Device Class Hierarchy:**
+
+```
+TwoWayDisplayBase
+    ↓
+Christie4K7HsController / Christie4K25RgbController
+    ├─ Implements: ITwoWayDisplayWithAudio, IOnline, ICommunicationMonitor, IBridgeAdvanced
+    ├─ Uses: CommunicationGather, GenericCommunicationMonitor
+    ├─ Commands: Power (PWR), Input Select (SIN), Video Mute (SHU), Lamp Hours (ILI)
+    └─ State Management: Warm-up/Cool-down flags, Pending command flags, 100ms throttling
+```
+
+**Data Flow:**
+
+1. User action → PowerOn()/SetInput()/VideoMuteOn() methods
+2. Guard clauses check state → Send command or queue/skip
+3. Command queued in `_commandQueue` with 100ms throttling
+4. Device receives command and responds
+5. CommunicationGather buffers response until `\n` delimiter
+6. ProcessResponse() parses response and updates feedbacks
+7. State machine executes pending commands if transition complete
+8. Feedbacks update bridge automatically
+
+**Thread Safety:**
+
+- Command queue uses `_sendLock` (object) for thread-safe enqueue/dequeue operations
+- All state flags (IsWarmingUp, IsCoolingDown) are accessed safely within lock context
+- Timer callbacks execute on Essentials thread pool (safe for state updates)
+
+---
+
+**Generated:** January 28, 2026  
+**Framework Version:** PepperDash Essentials 2.5.1+  
+**Plugin Version:** 1.0.0  
+**Methodology:** SOURCE-FIRST EXTRACTION per COPILOT_README_PROMPTS.md

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ The Christie projector plugin uses device feedback responses to manage power sta
 - **PWR!11** = Warming Up (transition state - device is actively warming)
 
 **Safety Features:**
-- Minimum 25-second warm-up and cool-down periods are enforced (configurable, cannot be reduced below 25 seconds)
+- Minimum 30-second warm-up and cool-down periods are enforced (configurable, cannot be reduced below 30 seconds)
 - Power commands sent during opposite state transitions are automatically queued and executed after the current transition completes
 - Do NOT attempt to power on while device is warming, or power off while cooling - the plugin handles this automatically
 - Device responses drive all state flags, not timers alone. Timers serve as safety fallbacks only.
@@ -74,8 +74,8 @@ Both devices support identical communication methods (RS-232 serial and TCP/Netw
       }
     },
     "pollIntervalMs": 10000,
-    "warmingTimeMs": 25000,
-    "coolingTimeMs": 25000,
+    "warmingTimeMs": 30000,
+    "coolingTimeMs": 30000,
     "hasLamps": true,
     "hasScreen": false,
     "hasLift": false
@@ -108,8 +108,8 @@ Both devices support identical communication methods (RS-232 serial and TCP/Netw
       }
     },
     "pollIntervalMs": 10000,
-    "warmingTimeMs": 25000,
-    "coolingTimeMs": 25000,
+    "warmingTimeMs": 30000,
+    "coolingTimeMs": 30000,
     "hasLamps": true,
     "hasScreen": false,
     "hasLift": false
@@ -141,8 +141,8 @@ Both devices support identical communication methods (RS-232 serial and TCP/Netw
         }
       },
       "pollIntervalMs": 10000,
-      "warmingTimeMs": 25000,
-      "coolingTimeMs": 25000,
+      "warmingTimeMs": 30000,
+      "coolingTimeMs": 30000,
       "hasLamps": true,
       "hasScreen": false,
       "hasLift": false
@@ -169,8 +169,8 @@ Both devices support identical communication methods (RS-232 serial and TCP/Netw
         }
       },
       "pollIntervalMs": 10000,
-      "warmingTimeMs": 25000,
-      "coolingTimeMs": 25000,
+      "warmingTimeMs": 30000,
+      "coolingTimeMs": 30000,
       "hasLamps": true,
       "hasScreen": false,
       "hasLift": false
@@ -189,7 +189,7 @@ Both devices support identical communication methods (RS-232 serial and TCP/Netw
 
 | Feature | 4K7-HS | 4K25-RGB | Notes |
 |---------|--------|----------|-------|
-| Power On/Off | ✓ | ✓ | Managed with 25-second warm-up/cool-down |
+| Power On/Off | ✓ | ✓ | Managed with 30-second warm-up/cool-down |
 | Input Selection | ✓ | ✓ | HDMI, DigitalLink, and other inputs |
 | Video Mute | ✓ | ✓ | Blanks display output (SHU command) |
 | Power States | ✓ | ✓ | OFF, Warming, Fully On, Cooling |
@@ -214,8 +214,8 @@ Both devices support identical communication methods (RS-232 serial and TCP/Netw
 | `group` | string | ✓ | - | Device grouping (e.g., `"displays"`, `"projectors"`) |
 | `control` | object | ✓ | - | Communication control configuration (TCP or Serial) |
 | `pollIntervalMs` | long | ✗ | 10000 | Status poll interval in milliseconds (minimum 10000) |
-| `warmingTimeMs` | long | ✗ | 25000 | Device warm-up period in milliseconds (minimum 25000) |
-| `coolingTimeMs` | long | ✗ | 25000 | Device cool-down period in milliseconds (minimum 25000) |
+| `warmingTimeMs` | long | ✗ | 30000 | Device warm-up period in milliseconds (minimum 30000) |
+| `coolingTimeMs` | long | ✗ | 30000 | Device cool-down period in milliseconds (minimum 30000) |
 | `hasLamps` | bool | ✗ | false | Device has lamp indicator for feedback purposes |
 | `hasScreen` | bool | ✗ | false | Device has screen for feedback purposes |
 | `hasLift` | bool | ✗ | false | Device has motorized lift for feedback purposes |
@@ -272,18 +272,18 @@ Both devices support identical communication methods (RS-232 serial and TCP/Netw
   - Values below 10000 ms will be forced to 10000 ms by the plugin
 
 - **`warmingTimeMs`:** Duration (in milliseconds) to wait for device to complete power-on warm-up cycle.
-  - **Minimum enforced:** 25000 ms (25 seconds)
-  - **Must match actual device warm-up time:** Real Christie projectors require ~25 seconds to fully warm up
-  - **Recommended:** 25000 ms (do not increase unless device specifically requires longer)
+  - **Minimum enforced:** 30000 ms (30 seconds)
+  - **Must match actual device warm-up time:** Real Christie projectors require ~30 seconds to fully warm up
+  - **Recommended:** 30000 ms (do not increase unless device specifically requires longer)
   - **Safety:** Commands cannot be sent to device during warm-up period
-  - Values below 25000 ms will be forced to 25000 ms by the plugin
+  - Values below 30000 ms will be forced to 30000 ms by the plugin
 
 - **`coolingTimeMs`:** Duration (in milliseconds) to wait for device to complete power-off cool-down cycle.
-  - **Minimum enforced:** 25000 ms (25 seconds)
-  - **Must match actual device cool-down time:** Real Christie projectors require ~25 seconds to fully cool down
-  - **Recommended:** 25000 ms (do not increase unless device specifically requires longer)
+  - **Minimum enforced:** 30000 ms (30 seconds)
+  - **Must match actual device cool-down time:** Real Christie projectors require ~30 seconds to fully cool down
+  - **Recommended:** 30000 ms (do not increase unless device specifically requires longer)
   - **Safety:** Commands cannot be sent to device during cool-down period
-  - Values below 25000 ms will be forced to 25000 ms by the plugin
+  - Values below 30000 ms will be forced to 30000 ms by the plugin
 
 **Device Capabilities:**
 
@@ -533,7 +533,7 @@ When device reaches confirmed state:
 
 **Timing Configuration:**
 
-- **Warming Time:** Must be ≥ 25000 ms to allow device full warm-up cycle
+- **Warming Time:** Must be ≥ 30000 ms to allow device full warm-up cycle
 - **Cooling Time:** Must be ≥ 25000 ms to allow device full cool-down cycle
 - **Poll Interval:** Minimum 10000 ms; higher intervals reduce network traffic but increase feedback latency
 - **Never modify minimum values** - they are enforced by device firmware and safety requirements

--- a/src/Christie4K25RgbController.cs
+++ b/src/Christie4K25RgbController.cs
@@ -262,6 +262,12 @@ namespace ChristieProjectorPlugin
 		{
 			if (string.IsNullOrEmpty(response)) return;
 
+			// Handle error responses
+			if (response.Contains("ERR"))
+			{
+				this.LogWarning("ProcessResponse: Device error - {response}", response);
+				return;
+			}
 
 			var responseValue = 0;
 			var responseType = "";
@@ -1028,7 +1034,8 @@ namespace ChristieProjectorPlugin
 		/// </summary>
 		public void VideoMuteGet()
 		{
-			SendText("SHU", "?");
+			// SHU command is disabled on this device
+			return;
 		}
 
 		/// <summary>
@@ -1036,11 +1043,8 @@ namespace ChristieProjectorPlugin
 		/// </summary>
 		public void VideoMuteOn()
 		{
-			SendText("SHU", 1);
-
-			Thread.Sleep(25);
-			VideoMuteGet();
-
+			// SHU command is disabled on this device
+			return;
 		}
 
 		/// <summary>
@@ -1048,10 +1052,8 @@ namespace ChristieProjectorPlugin
 		/// </summary>
 		public void VideoMuteOff()
 		{
-			SendText("SHU", 0);
-
-			Thread.Sleep(25);
-			VideoMuteGet();
+			// SHU command is disabled on this device
+			return;
 		}
 
 		/// <summary>

--- a/src/Christie4K25RgbController.cs
+++ b/src/Christie4K25RgbController.cs
@@ -60,7 +60,7 @@ namespace ChristieProjectorPlugin
 
 			_isSerialComm = !(Communication is ISocketStatus socket);
 
-			var pollIntervalMs = props.PollIntervalMs > 45000 ? props.PollIntervalMs : 45000;
+			var pollIntervalMs = props.PollIntervalMs >= 10000 ? props.PollIntervalMs : 10000;
 			CommunicationMonitor = new GenericCommunicationMonitor(this, Communication, pollIntervalMs, 180000, 300000,
 				StatusGet);
 
@@ -309,7 +309,20 @@ namespace ChristieProjectorPlugin
 			{
 				case "PWR":
 					{
-						PowerIsOn = responseValue == 1;
+						bool newPowerState = responseValue == 1;
+						PowerIsOn = newPowerState;
+						
+						// Clear warming/cooling flags when we get the actual power feedback
+						if (newPowerState && IsWarmingUp)
+						{
+							IsWarmingUp = false; // Got power on feedback, clear warming
+							this.LogVerbose("ProcessResponse: Received PWR!1 feedback, clearing IsWarmingUp");
+						}
+						else if (!newPowerState && IsCoolingDown)
+						{
+							IsCoolingDown = false; // Got power off feedback, clear cooling
+							this.LogVerbose("ProcessResponse: Received PWR!0 feedback, clearing IsCoolingDown");
+						}
 						break;
 					}
 				case "SIN":
@@ -362,7 +375,8 @@ namespace ChristieProjectorPlugin
 
 		/// <summary>
 		/// Queues a formatted command for sending with state checking and throttling.
-		/// Commands are held if device is warming up or cooling down, then sent when ready.
+		/// Control commands trigger warming/cooling flags based on the command type.
+		/// Query commands (containing ?) are sent immediately without queuing.
 		/// </summary>
 		private void SendCommandQueued(string text)
 		{
@@ -374,11 +388,49 @@ namespace ChristieProjectorPlugin
 				return;
 			}
 
+			// Query commands (containing ?) bypass queue and send immediately
+			if (text.Contains("?"))
+			{
+				lock (_sendLock)
+				{
+					try
+					{
+						Communication.SendText(text);
+						this.LogVerbose("SendCommandQueued: Query sent immediately: {text}", text);
+					}
+					catch (Exception ex)
+					{
+						this.LogError(ex, "Exception sending query command");
+					}
+				}
+				return;
+			}
+
 			lock (_sendLock)
 			{
+				// Check if this is a power control command (not a query)
+				// PWR!1 = power on -> expect warming
+				// PWR!0 = power off -> expect cooling
+				if (text.Contains("(PWR!1)"))
+				{
+					if (!IsWarmingUp)
+					{
+						IsWarmingUp = true;
+						this.LogVerbose("SendCommandQueued: Power ON command queued, setting IsWarmingUp=true. Warming time: {WarmupTimeMs}ms", WarmupTime);
+					}
+				}
+				else if (text.Contains("(PWR!0)"))
+				{
+					if (!IsCoolingDown)
+					{
+						IsCoolingDown = true;
+						this.LogVerbose("SendCommandQueued: Power OFF command queued, setting IsCoolingDown=true. Cooling time: {CooldownTimeMs}ms", CooldownTime);
+					}
+				}
+
 				// Queue the command
 				_commandQueue.Enqueue(text);
-				this.LogVerbose("SendCommandQueued: Command queued: {text}. Queue size: {queueSize}", text, _commandQueue.Count);
+				this.LogVerbose("SendCommandQueued: Control command queued: {text}. Queue size: {queueSize}", text, _commandQueue.Count);
 				
 				// Try to process queue
 				ProcessCommandQueue();
@@ -387,23 +439,24 @@ namespace ChristieProjectorPlugin
 
 		/// <summary>
 		/// Processes the command queue, sending commands only when device is ready.
+		/// Only control commands are in queue; queries are sent immediately bypassing queue.
 		/// Commands are held if device is warming or cooling.
 		/// </summary>
 		private void ProcessCommandQueue()
 		{
-			// Don't send if device is warming or cooling
-			if (IsWarmingUp || IsCoolingDown)
-			{
-				this.LogVerbose("ProcessCommandQueue: Device warming={IsWarmingUp} or cooling={IsCoolingDown}. Queue held.", IsWarmingUp, IsCoolingDown);
-				return;
-			}
-
 			while (_commandQueue.Count > 0)
 			{
+				string text = _commandQueue.Peek();
+				
+				// Block control commands if warming or cooling
+				if (IsWarmingUp || IsCoolingDown)
+				{
+					this.LogVerbose("ProcessCommandQueue: Device warming={IsWarmingUp} or cooling={IsCoolingDown}. Queue held.", IsWarmingUp, IsCoolingDown);
+					return;
+				}
+
 				try
 				{
-					string text = _commandQueue.Peek();
-
 					// Calculate time to wait based on minimum send interval
 					long currentTimeMs = Convert.ToInt64(DateTime.Now.ToUniversalTime().Subtract(new DateTime(1970, 1, 1, 0, 0, 0, DateTimeKind.Utc)).TotalMilliseconds);
 					long timeSinceLastSendMs = currentTimeMs - _lastSendTimeMs;

--- a/src/Christie4K25RgbController.cs
+++ b/src/Christie4K25RgbController.cs
@@ -1175,9 +1175,6 @@ namespace ChristieProjectorPlugin
 
 		#region Power State Management
 
-		private bool _pendingPowerOn;
-		private bool _pendingPowerOff;
-
 		#endregion
 
 		#region videoMute

--- a/src/Christie4K25RgbController.cs
+++ b/src/Christie4K25RgbController.cs
@@ -446,13 +446,13 @@ namespace ChristieProjectorPlugin
 						this.LogVerbose("SendCommandQueued: Power ON command queued, setting IsWarmingUp=true. Warming time: {WarmupTimeMs}ms", WarmupTime);
 					}
 				}
-			}
-			else if (text.Contains("(PWR!0)"))
-			{
-				if (!IsCoolingDown)
+				else if (text.Contains("(PWR!0)"))
 				{
-					IsCoolingDown = true;
-					this.LogWarning("SendCommandQueued: Power OFF command - setting IsCoolingDown=true. Cooling time: {CooldownTime}ms", CooldownTime);
+					if (!IsCoolingDown)
+					{
+						IsCoolingDown = true;
+						this.LogWarning("SendCommandQueued: Power OFF command - setting IsCoolingDown=true. Cooling time: {CooldownTime}ms", CooldownTime);
+					}
 				}
 
 				// Queue the command
@@ -1174,6 +1174,9 @@ namespace ChristieProjectorPlugin
 
 
 		#region Power State Management
+
+		private bool _pendingPowerOn;
+		private bool _pendingPowerOff;
 
 		#endregion
 

--- a/src/Christie4K25RgbController.cs
+++ b/src/Christie4K25RgbController.cs
@@ -262,12 +262,6 @@ namespace ChristieProjectorPlugin
 		{
 			if (string.IsNullOrEmpty(response)) return;
 
-			// Handle error responses
-			if (response.Contains("ERR"))
-			{
-				this.LogWarning("ProcessResponse: Device error - {response}", response);
-				return;
-			}
 
 			var responseValue = 0;
 			var responseType = "";
@@ -1034,8 +1028,7 @@ namespace ChristieProjectorPlugin
 		/// </summary>
 		public void VideoMuteGet()
 		{
-			// SHU command is disabled on this device
-			return;
+			SendText("SHU", "?");
 		}
 
 		/// <summary>
@@ -1043,8 +1036,11 @@ namespace ChristieProjectorPlugin
 		/// </summary>
 		public void VideoMuteOn()
 		{
-			// SHU command is disabled on this device
-			return;
+			SendText("SHU", 1);
+
+			Thread.Sleep(25);
+			VideoMuteGet();
+
 		}
 
 		/// <summary>
@@ -1052,8 +1048,10 @@ namespace ChristieProjectorPlugin
 		/// </summary>
 		public void VideoMuteOff()
 		{
-			// SHU command is disabled on this device
-			return;
+			SendText("SHU", 0);
+
+			Thread.Sleep(25);
+			VideoMuteGet();
 		}
 
 		/// <summary>

--- a/src/Christie4K25RgbController.cs
+++ b/src/Christie4K25RgbController.cs
@@ -464,7 +464,7 @@ namespace ChristieProjectorPlugin
 			}
 		}
 
-		/// <summary>
+		/// <summary> ///
 		/// Processes the command queue, sending commands only when device is ready.
 		/// Only control commands are in queue; queries are sent immediately bypassing queue.
 		/// Commands are held if device is warming or cooling.

--- a/src/Christie4K25RgbController.cs
+++ b/src/Christie4K25RgbController.cs
@@ -235,6 +235,10 @@ namespace ChristieProjectorPlugin
 		private const string GatherDelimiter = @"\)";
 
 		private readonly GenericQueue _receiveQueue;
+		private long _lastSendTimeMs = 0;
+		private const int MinSendIntervalMs = 100; // Minimum milliseconds between sends
+		private readonly object _sendLock = new object();
+		private readonly Queue<string> _commandQueue = new Queue<string>();
 
 		private void OnCommunicationMonitorStatusChange(object sender, MonitorStatusChangeEventArgs args)
 		{
@@ -336,14 +340,8 @@ namespace ChristieProjectorPlugin
 		{
 			if (string.IsNullOrEmpty(cmd)) return;
 
-			if (!Communication.IsConnected)
-			{
-				this.LogWarning("SendText: device not connected");
-				return;
-			}
-
 			var text = string.Format("({0})", cmd);
-			Communication.SendText(text);
+			SendCommandQueued(text);
 		}
 
 		// formats outgoing message
@@ -352,14 +350,83 @@ namespace ChristieProjectorPlugin
 			var text = string.IsNullOrEmpty(value)
 				? "?"
 				: string.Format("({0}{1})", cmd, value);
-			Communication.SendText(text);
+			SendCommandQueued(text);
 		}
 
 		// formats outgoing message
 		private void SendText(string cmd, int value)
 		{
 			// tx format: "({cmd}{value})]"
-			Communication.SendText(string.Format("({0}{1})", cmd, value));
+			SendCommandQueued(string.Format("({0}{1})", cmd, value));
+		}
+
+		/// <summary>
+		/// Queues a formatted command for sending with state checking and throttling.
+		/// Commands are held if device is warming up or cooling down, then sent when ready.
+		/// </summary>
+		private void SendCommandQueued(string text)
+		{
+			if (string.IsNullOrEmpty(text)) return;
+
+			if (!Communication.IsConnected)
+			{
+				this.LogWarning("SendCommandQueued: device not connected");
+				return;
+			}
+
+			lock (_sendLock)
+			{
+				// Queue the command
+				_commandQueue.Enqueue(text);
+				this.LogVerbose("SendCommandQueued: Command queued: {text}. Queue size: {queueSize}", text, _commandQueue.Count);
+				
+				// Try to process queue
+				ProcessCommandQueue();
+			}
+		}
+
+		/// <summary>
+		/// Processes the command queue, sending commands only when device is ready.
+		/// Commands are held if device is warming or cooling.
+		/// </summary>
+		private void ProcessCommandQueue()
+		{
+			// Don't send if device is warming or cooling
+			if (IsWarmingUp || IsCoolingDown)
+			{
+				this.LogVerbose("ProcessCommandQueue: Device warming={IsWarmingUp} or cooling={IsCoolingDown}. Queue held.", IsWarmingUp, IsCoolingDown);
+				return;
+			}
+
+			while (_commandQueue.Count > 0)
+			{
+				try
+				{
+					string text = _commandQueue.Peek();
+
+					// Calculate time to wait based on minimum send interval
+					long currentTimeMs = Convert.ToInt64(DateTime.Now.ToUniversalTime().Subtract(new DateTime(1970, 1, 1, 0, 0, 0, DateTimeKind.Utc)).TotalMilliseconds);
+					long timeSinceLastSendMs = currentTimeMs - _lastSendTimeMs;
+
+					if (timeSinceLastSendMs < MinSendIntervalMs)
+					{
+						long delayMs = MinSendIntervalMs - timeSinceLastSendMs;
+						this.LogVerbose("ProcessCommandQueue: Throttling for {delayMs}ms", delayMs);
+						Thread.Sleep((int)delayMs);
+					}
+
+					// Send the command
+					Communication.SendText(text);
+					_lastSendTimeMs = Convert.ToInt64(DateTime.Now.ToUniversalTime().Subtract(new DateTime(1970, 1, 1, 0, 0, 0, DateTimeKind.Utc)).TotalMilliseconds);
+					_commandQueue.Dequeue(); // Remove from queue after successful send
+					this.LogVerbose("ProcessCommandQueue: Sent {text}. Remaining in queue: {queueSize}", text, _commandQueue.Count);
+				}
+				catch (Exception ex)
+				{
+					this.LogError(ex, "Exception in ProcessCommandQueue");
+					break; // Stop processing if there's an error
+				}
+			}
 		}
 
 		/// <summary>
@@ -457,7 +524,20 @@ namespace ChristieProjectorPlugin
 					{
 						_isWarmingUp = false;
 						IsWarmingUpFeedback.FireUpdate();
+						// Process any queued commands now that warmup is complete
+						lock (_sendLock)
+						{
+							ProcessCommandQueue();
+						}
 					}, WarmupTime);
+				}
+				else
+				{
+					// Warmup completed, process queued commands
+					lock (_sendLock)
+					{
+						ProcessCommandQueue();
+					}
 				}
 			}
 		}
@@ -479,7 +559,20 @@ namespace ChristieProjectorPlugin
 					{
 						_isCoolingDown = false;
 						IsCoolingDownFeedback.FireUpdate();
+						// Process any queued commands now that cooldown is complete
+						lock (_sendLock)
+						{
+							ProcessCommandQueue();
+						}
 					}, CooldownTime);
+				}
+				else
+				{
+					// Cooldown completed, process queued commands
+					lock (_sendLock)
+					{
+						ProcessCommandQueue();
+					}
 				}
 			}
 		}

--- a/src/Christie4K25RgbController.cs
+++ b/src/Christie4K25RgbController.cs
@@ -1019,7 +1019,7 @@ namespace ChristieProjectorPlugin
 
 
 		/// <summary>
-		/// Gets or sets the feedback object for video mute state
+		/// Gets the feedback object for video mute state
 		/// </summary>
 		public BoolFeedback VideoMuteIsOn { get; private set; }
 

--- a/src/Christie4K25RgbController.cs
+++ b/src/Christie4K25RgbController.cs
@@ -21,7 +21,7 @@ namespace ChristieProjectorPlugin
 	/// input routing, power management, and video mute functionality
 	/// </summary>
 	public class Christie4K25RgbController : TwoWayDisplayBase, ICommunicationMonitor,
-		IBridgeAdvanced, IHasInputs<string>, IRoutingSinkWithSwitchingWithInputPort
+		IBridgeAdvanced, IHasInputs<string>, IRoutingSinkWithSwitchingWithInputPort, IBasicVideoMuteWithFeedback
 	{
 
 		private bool _isSerialComm;
@@ -68,7 +68,7 @@ namespace ChristieProjectorPlugin
 
 			DeviceManager.AddDevice(CommunicationMonitor);
 
-			VideoMuteIsOnFeedback = new BoolFeedback(() => VideoMuteIsOn);
+			VideoMuteIsOn = new BoolFeedback(() => _videoMuteState);
 
 			WarmupTime = props.WarmingTimeMs > 30000 ? props.WarmingTimeMs : 30000;
 			CooldownTime = props.CoolingTimeMs > 30000 ? props.CoolingTimeMs : 30000;
@@ -180,8 +180,8 @@ namespace ChristieProjectorPlugin
 			trilist.SetSigTrueAction(joinMap.VideoMuteOn.JoinNumber, VideoMuteOn);
 			trilist.SetSigTrueAction(joinMap.VideoMuteOff.JoinNumber, VideoMuteOff);
 			trilist.SetSigTrueAction(joinMap.VideoMuteToggle.JoinNumber, VideoMuteToggle);
-			VideoMuteIsOnFeedback.LinkInputSig(trilist.BooleanInput[joinMap.VideoMuteOn.JoinNumber]);
-			VideoMuteIsOnFeedback.LinkComplementInputSig(trilist.BooleanInput[joinMap.VideoMuteOff.JoinNumber]);
+			VideoMuteIsOn.LinkInputSig(trilist.BooleanInput[joinMap.VideoMuteOn.JoinNumber]);
+			VideoMuteIsOn.LinkComplementInputSig(trilist.BooleanInput[joinMap.VideoMuteOff.JoinNumber]);
 
 			// bridge online change
 			trilist.OnlineStatusChange += (sender, args) =>
@@ -315,7 +315,8 @@ namespace ChristieProjectorPlugin
 					}
 				case "SHU":
 					{
-						VideoMuteIsOn = responseValue == 1;
+						_videoMuteState = responseValue == 1;
+						VideoMuteIsOn.FireUpdate();
 						break;
 					}
 				default:
@@ -1014,31 +1015,13 @@ namespace ChristieProjectorPlugin
 
 		#region videoMute
 
-		private bool _videoMuteIsOn;
+		private bool _videoMuteState;
 
-
-		/// <summary>
-		/// Gets or sets the video mute state of the projector
-		/// </summary>
-		public bool VideoMuteIsOn
-		{
-			get { return _videoMuteIsOn; }
-			set
-			{
-				if (_videoMuteIsOn == value)
-				{
-					return;
-				}
-
-				_videoMuteIsOn = value;
-				VideoMuteIsOnFeedback.FireUpdate();
-			}
-		}
 
 		/// <summary>
 		/// Gets or sets the feedback object for video mute state
 		/// </summary>
-		public BoolFeedback VideoMuteIsOnFeedback;
+		public BoolFeedback VideoMuteIsOn { get; private set; }
 
 		/// <summary>
 		/// Polls the projector for current video mute status
@@ -1076,7 +1059,7 @@ namespace ChristieProjectorPlugin
 		/// </summary>
 		public void VideoMuteToggle()
 		{
-			if (VideoMuteIsOn)
+			if (VideoMuteIsOn.BoolValue)
 				VideoMuteOff();
 			else
 				VideoMuteOn();

--- a/src/Christie4K25RgbController.cs
+++ b/src/Christie4K25RgbController.cs
@@ -70,11 +70,13 @@ namespace ChristieProjectorPlugin
 
 			VideoMuteIsOn = new BoolFeedback(() => _videoMuteState);
 
+		WarmupTime = props.WarmingTimeMs > 30000 ? props.WarmingTimeMs : 30000;
+		CooldownTime = props.CoolingTimeMs > 30000 ? props.CoolingTimeMs : 30000;
+
 		_pendingPowerOn = false;
 		_pendingPowerOff = false;
 
-
-			HasLamps = props.HasLamps;
+		HasLamps = props.HasLamps;
 			HasScreen = props.HasScreen;
 			HasLift = props.HasLift;
 
@@ -290,8 +292,9 @@ namespace ChristieProjectorPlugin
 
 				if (!response.Contains("!")) return;
 
+			var pattern = new Regex(@"\((?<command>[^!]+)!(?<value>\d+)(?: ""(?<data>.+?)"")?", RegexOptions.None);
 			this.LogVerbose("ProcessResponse: Raw response-'{response}'", response);
-				var match = pattern.Match(response);
+			var match = pattern.Match(response);
 				responseType = match.Groups["command"].Value;
 				var responseString = match.Groups["value"].Value;
 				string responseData = match.Groups["data"].Value;
@@ -443,17 +446,13 @@ namespace ChristieProjectorPlugin
 						this.LogVerbose("SendCommandQueued: Power ON command queued, setting IsWarmingUp=true. Warming time: {WarmupTimeMs}ms", WarmupTime);
 					}
 				}
-if (text.Contains("(PWR!0)"))
+			}
+			else if (text.Contains("(PWR!0)"))
 			{
 				if (!IsCoolingDown)
 				{
 					IsCoolingDown = true;
 					this.LogWarning("SendCommandQueued: Power OFF command - setting IsCoolingDown=true. Cooling time: {CooldownTime}ms", CooldownTime);
-				}
-				else
-				{
-					this.LogWarning("SendCommandQueued: Power OFF command but IsCoolingDown already true!");
-					}
 				}
 
 				// Queue the command
@@ -682,9 +681,7 @@ if (text.Contains("(PWR!0)"))
 				return;
 			}
 
-			if (PowerIsOn == false) IsWarmingUp = true;
-
-			SendText("PWR", 1);
+		if (!PowerIsOn) IsWarmingUp = true;
 
 			PowerGet();
 
@@ -708,9 +705,7 @@ if (text.Contains("(PWR!0)"))
 				return;
 			}
 
-			if (PowerIsOn == true) IsCoolingDown = true;
-
-			SendText("PWR", 0);
+		if (PowerIsOn) IsCoolingDown = true;
 
 			PowerGet();
 
@@ -1177,13 +1172,6 @@ if (text.Contains("(PWR!0)"))
 
 
 
-
-		#region Power State Flags
-
-		private bool _pendingPowerOn;
-		private bool _pendingPowerOff;
-
-		#endregion
 
 		#region Power State Management
 

--- a/src/Christie4K25RgbController.cs
+++ b/src/Christie4K25RgbController.cs
@@ -70,8 +70,9 @@ namespace ChristieProjectorPlugin
 
 			VideoMuteIsOn = new BoolFeedback(() => _videoMuteState);
 
-			WarmupTime = props.WarmingTimeMs > 30000 ? props.WarmingTimeMs : 30000;
-			CooldownTime = props.CoolingTimeMs > 30000 ? props.CoolingTimeMs : 30000;
+		_pendingPowerOn = false;
+		_pendingPowerOff = false;
+
 
 			HasLamps = props.HasLamps;
 			HasScreen = props.HasScreen;
@@ -249,7 +250,7 @@ namespace ChristieProjectorPlugin
 		{
 			try
 			{
-				this.LogVerbose("OnCommunicationGatherLineReceived: args.Text-'{0}'", args.Text);
+				//this.LogVerbose("OnCommunicationGatherLineReceived: args.Text-'{0}'", args.Text);
 				_receiveQueue.Enqueue(new ProcessStringMessage(args.Text, ProcessResponse));
 			}
 			catch (Exception ex)
@@ -289,9 +290,7 @@ namespace ChristieProjectorPlugin
 
 				if (!response.Contains("!")) return;
 
-				this.LogVerbose("ProcessResponse: {response}", response);
-
-				var pattern = new Regex(@"\((?<command>[^!]+)!(?<value>\d+)(?: ""(?<data>.+?)"")?", RegexOptions.None);
+			this.LogVerbose("ProcessResponse: Raw response-'{response}'", response);
 				var match = pattern.Match(response);
 				responseType = match.Groups["command"].Value;
 				var responseString = match.Groups["value"].Value;
@@ -304,27 +303,52 @@ namespace ChristieProjectorPlugin
 				this.LogError(ex, "ProcessResponse exception");
 			}
 
-			this.LogVerbose("ProcessResponse: responseType-{responseType}, responseValue-{responseValue}", responseType, responseValue);
-			switch (responseType)
-			{
-				case "PWR":
+		switch (responseType)
+		{
+			case "PWR":
+				{
+					// responseValue: 0=OFF, 1=ON, 10=cooling, 11=warming
+					
+					// Device is warming up
+					if (responseValue == 11)
 					{
-						bool newPowerState = responseValue == 1;
-						PowerIsOn = newPowerState;
-						
-						// Clear warming/cooling flags when we get the actual power feedback
-						if (newPowerState && IsWarmingUp)
-						{
-							IsWarmingUp = false; // Got power on feedback, clear warming
-							this.LogVerbose("ProcessResponse: Received PWR!1 feedback, clearing IsWarmingUp");
-						}
-						else if (!newPowerState && IsCoolingDown)
-						{
-							IsCoolingDown = false; // Got power off feedback, clear cooling
-							this.LogVerbose("ProcessResponse: Received PWR!0 feedback, clearing IsCoolingDown");
-						}
-						break;
+						IsWarmingUp = true;
+						this.LogVerbose("ProcessResponse: Device warming (PWR!11)");
 					}
+					// Device is cooling down
+					else if (responseValue == 10)
+					{
+						IsCoolingDown = true;
+						this.LogVerbose("ProcessResponse: Device cooling (PWR!10)");
+					}
+					// Warmup CONFIRMED (PWR!01)
+					else if (responseValue == 1)
+					{
+						IsWarmingUp = false;
+						this.LogWarning("ProcessResponse: Warmup confirmed (PWR!01). Checking pending commands.");
+						if (_pendingPowerOff)
+						{
+							_pendingPowerOff = false;
+							this.LogWarning("ProcessResponse: Executing pending PowerOff");
+							PowerOff();
+						}
+					}
+					// Cooldown CONFIRMED (PWR!00)
+					else if (responseValue == 0)
+					{
+						IsCoolingDown = false;
+						this.LogWarning("ProcessResponse: Cooldown confirmed (PWR!00). Checking pending commands.");
+						if (_pendingPowerOn)
+						{
+							_pendingPowerOn = false;
+							this.LogWarning("ProcessResponse: Executing pending PowerOn");
+							PowerOn();
+						}
+					}
+					
+					PowerIsOn = (responseValue == 1);
+					break;
+				}
 				case "SIN":
 					{
 						UpdateInputFb(responseValue);
@@ -338,7 +362,7 @@ namespace ChristieProjectorPlugin
 					}
 				default:
 					{
-						this.LogVerbose("ProcessResponse: unknown response {responseType}", responseType);
+						//this.LogVerbose("ProcessResponse: unknown response {responseType}", responseType);
 						break;
 					}
 			}
@@ -419,12 +443,16 @@ namespace ChristieProjectorPlugin
 						this.LogVerbose("SendCommandQueued: Power ON command queued, setting IsWarmingUp=true. Warming time: {WarmupTimeMs}ms", WarmupTime);
 					}
 				}
-				else if (text.Contains("(PWR!0)"))
+if (text.Contains("(PWR!0)"))
+			{
+				if (!IsCoolingDown)
 				{
-					if (!IsCoolingDown)
-					{
-						IsCoolingDown = true;
-						this.LogVerbose("SendCommandQueued: Power OFF command queued, setting IsCoolingDown=true. Cooling time: {CooldownTimeMs}ms", CooldownTime);
+					IsCoolingDown = true;
+					this.LogWarning("SendCommandQueued: Power OFF command - setting IsCoolingDown=true. Cooling time: {CooldownTime}ms", CooldownTime);
+				}
+				else
+				{
+					this.LogWarning("SendCommandQueued: Power OFF command but IsCoolingDown already true!");
 					}
 				}
 
@@ -447,13 +475,6 @@ namespace ChristieProjectorPlugin
 			while (_commandQueue.Count > 0)
 			{
 				string text = _commandQueue.Peek();
-				
-				// Block control commands if warming or cooling
-				if (IsWarmingUp || IsCoolingDown)
-				{
-					this.LogVerbose("ProcessCommandQueue: Device warming={IsWarmingUp} or cooling={IsCoolingDown}. Queue held.", IsWarmingUp, IsCoolingDown);
-					return;
-				}
 
 				try
 				{
@@ -523,12 +544,10 @@ namespace ChristieProjectorPlugin
 
 			if (!PowerIsOn) return;
 
-			CrestronEnvironment.Sleep(2000);
 			InputGet();
 
 			if (!HasLamps) return;
 
-			CrestronEnvironment.Sleep(2000);
 			LampGet();
 		}
 
@@ -650,13 +669,22 @@ namespace ChristieProjectorPlugin
 		/// </summary>
 		public override void PowerOn()
 		{
-			if (IsWarmingUp || IsCoolingDown) return;
+			this.LogWarning("PowerOn called: IsWarmingUp={IsWarmingUp}, IsCoolingDown={IsCoolingDown}, PowerIsOn={PowerIsOn}", IsWarmingUp, IsCoolingDown, PowerIsOn);
+			
+			// Don't send duplicate power on if already warming
+			if (IsWarmingUp) return;
+
+			// Queue pending power on if cooling down, execute normally if not cooling
+			if (IsCoolingDown)
+			{
+				_pendingPowerOn = true;
+				this.LogWarning("PowerOn queued (cooling down)");
+				return;
+			}
 
 			if (PowerIsOn == false) IsWarmingUp = true;
 
 			SendText("PWR", 1);
-
-			Thread.Sleep(1500);
 
 			PowerGet();
 
@@ -667,14 +695,22 @@ namespace ChristieProjectorPlugin
 		/// </summary>
 		public override void PowerOff()
 		{
-			if (IsWarmingUp || IsCoolingDown) return;
+			this.LogWarning("PowerOff called: PowerIsOn={PowerIsOn}, IsWarmingUp={IsWarmingUp}, IsCoolingDown={IsCoolingDown}", PowerIsOn, IsWarmingUp, IsCoolingDown);
+
+			// Don't send duplicate power off if already cooling
+			if (IsCoolingDown) return;
+
+			// Queue pending power off if warming up, execute normally if not warming
+			if (IsWarmingUp)
+			{
+				_pendingPowerOff = true;
+				this.LogWarning("PowerOff queued (warming up)");
+				return;
+			}
 
 			if (PowerIsOn == true) IsCoolingDown = true;
 
 			SendText("PWR", 0);
-
-
-			Thread.Sleep(50);
 
 			PowerGet();
 
@@ -907,7 +943,6 @@ namespace ChristieProjectorPlugin
 		public void InputHdmi1()
 		{
 			SendText("SIN", 1);
-			Thread.Sleep(2000);
 			InputGet();
 		}
 
@@ -917,7 +952,6 @@ namespace ChristieProjectorPlugin
 		public void InputHdmi2()
 		{
 			SendText("SIN", 2);
-			Thread.Sleep(2000);
 			InputGet();
 		}
 
@@ -927,7 +961,6 @@ namespace ChristieProjectorPlugin
 		public void InputHdbaseT()
 		{
 			SendText("SIN", 3);
-			Thread.Sleep(2000);
 			InputGet();
 		}
 
@@ -938,7 +971,6 @@ namespace ChristieProjectorPlugin
 		public void InputDisplayPort1()
 		{
 			SendText("SIN", 4);
-			Thread.Sleep(2000);
 			InputGet();
 		}
 
@@ -948,7 +980,6 @@ namespace ChristieProjectorPlugin
 		public void InputDisplayPort2()
 		{
 			SendText("SIN", 5);
-			Thread.Sleep(2000);
 			InputGet();
 		}
 
@@ -958,8 +989,6 @@ namespace ChristieProjectorPlugin
 		public void InputSdi1()
 		{
 			SendText("SIN", 6);
-
-			Thread.Sleep(2000);
 			InputGet();
 		}
 
@@ -969,8 +998,6 @@ namespace ChristieProjectorPlugin
 		public void InputSdi2()
 		{
 			SendText("SIN", 7);
-
-			Thread.Sleep(2000);
 			InputGet();
 		}
 
@@ -980,8 +1007,6 @@ namespace ChristieProjectorPlugin
 		public void InputSdi3()
 		{
 			SendText("SIN", 8);
-
-			Thread.Sleep(2000);
 			InputGet();
 		}
 
@@ -991,8 +1016,6 @@ namespace ChristieProjectorPlugin
 		public void InputSdi4()
 		{
 			SendText("SIN", 9);
-
-			Thread.Sleep(2000);
 			InputGet();
 		}
 
@@ -1003,8 +1026,6 @@ namespace ChristieProjectorPlugin
 		public void InputDigitalLink1()
 		{
 			SendText("SIN", 10);
-
-			Thread.Sleep(2000);
 			InputGet();
 		}
 
@@ -1015,8 +1036,6 @@ namespace ChristieProjectorPlugin
 		public void InputDigitalLink2()
 		{
 			SendText("SIN", 11);
-
-			Thread.Sleep(2000);
 			InputGet();
 		}
 
@@ -1159,6 +1178,20 @@ namespace ChristieProjectorPlugin
 
 
 
+		#region Power State Flags
+
+		private bool _pendingPowerOn;
+		private bool _pendingPowerOff;
+
+		#endregion
+
+		#region Power State Management
+
+		private bool _pendingPowerOn;
+		private bool _pendingPowerOff;
+
+		#endregion
+
 		#region videoMute
 
 		private bool _videoMuteState;
@@ -1184,7 +1217,6 @@ namespace ChristieProjectorPlugin
 		{
 			SendText("SHU", 1);
 
-			Thread.Sleep(25);
 			VideoMuteGet();
 
 		}
@@ -1196,7 +1228,6 @@ namespace ChristieProjectorPlugin
 		{
 			SendText("SHU", 0);
 
-			Thread.Sleep(25);
 			VideoMuteGet();
 		}
 

--- a/src/Christie4K7HsController.cs
+++ b/src/Christie4K7HsController.cs
@@ -22,7 +22,7 @@ namespace ChristieProjectorPlugin
 	/// input routing, power management, and video mute functionality
 	/// </summary>
 	public class Christie4K7HsController : TwoWayDisplayBase, ICommunicationMonitor, IBridgeAdvanced,
-		IHasInputs<string>, IRoutingSinkWithSwitchingWithInputPort
+		IHasInputs<string>, IRoutingSinkWithSwitchingWithInputPort, IBasicVideoMuteWithFeedback
 	{
 
 		private bool _isSerialComm;
@@ -69,7 +69,7 @@ namespace ChristieProjectorPlugin
 
 			DeviceManager.AddDevice(CommunicationMonitor);
 
-			VideoMuteIsOnFeedback = new BoolFeedback(() => VideoMuteIsOn);
+			VideoMuteIsOn = new BoolFeedback(() => _videoMuteState);
 
 			WarmupTime = props.WarmingTimeMs > 30000 ? props.WarmingTimeMs : 30000;
 			CooldownTime = props.CoolingTimeMs > 30000 ? props.CoolingTimeMs : 30000;
@@ -178,8 +178,8 @@ namespace ChristieProjectorPlugin
 			trilist.SetSigTrueAction(joinMap.VideoMuteOn.JoinNumber, VideoMuteOn);
 			trilist.SetSigTrueAction(joinMap.VideoMuteOff.JoinNumber, VideoMuteOff);
 			trilist.SetSigTrueAction(joinMap.VideoMuteToggle.JoinNumber, VideoMuteToggle);
-			VideoMuteIsOnFeedback.LinkInputSig(trilist.BooleanInput[joinMap.VideoMuteOn.JoinNumber]);
-			VideoMuteIsOnFeedback.LinkComplementInputSig(trilist.BooleanInput[joinMap.VideoMuteOff.JoinNumber]);
+			VideoMuteIsOn.LinkInputSig(trilist.BooleanInput[joinMap.VideoMuteOn.JoinNumber]);
+			VideoMuteIsOn.LinkComplementInputSig(trilist.BooleanInput[joinMap.VideoMuteOff.JoinNumber]);
 
 			// bridge online change
 			trilist.OnlineStatusChange += (sender, args) =>
@@ -205,6 +205,7 @@ namespace ChristieProjectorPlugin
 				}
 
 				LampHoursFeedback.FireUpdate();
+				VideoMuteIsOn.FireUpdate();
 			};
 		}
 
@@ -303,7 +304,8 @@ namespace ChristieProjectorPlugin
 					}
 				case "SHU":
 					{
-						VideoMuteIsOn = responseValue == 1;
+						_videoMuteState = responseValue == 1;
+						VideoMuteIsOn.FireUpdate();
 						break;
 					}
 				default:
@@ -914,31 +916,13 @@ namespace ChristieProjectorPlugin
 
 		#region videoMute
 
-		private bool _videoMuteIsOn;
+		private bool _videoMuteState;
 
-
-		/// <summary>
-		/// Gets or sets the video mute state of the projector
-		/// </summary>
-		public bool VideoMuteIsOn
-		{
-			get { return _videoMuteIsOn; }
-			set
-			{
-				if (_videoMuteIsOn == value)
-				{
-					return;
-				}
-
-				_videoMuteIsOn = value;
-				VideoMuteIsOnFeedback.FireUpdate();
-			}
-		}
 
 		/// <summary>
 		/// Gets or sets the feedback object for video mute state
 		/// </summary>
-		public BoolFeedback VideoMuteIsOnFeedback;
+		public BoolFeedback VideoMuteIsOn { get; private set; }
 
 		/// <summary>
 		/// Polls the projector for current video mute status
@@ -975,7 +959,7 @@ namespace ChristieProjectorPlugin
 		/// </summary>
 		public void VideoMuteToggle()
 		{
-			if (VideoMuteIsOn)
+			if (VideoMuteIsOn.BoolValue)
 				VideoMuteOff();
 			else
 				VideoMuteOn();

--- a/src/Christie4K7HsController.cs
+++ b/src/Christie4K7HsController.cs
@@ -260,6 +260,14 @@ namespace ChristieProjectorPlugin
 		private void ProcessResponse(string response)
 		{
 			if (string.IsNullOrEmpty(response)) return;
+			
+			// Handle error responses
+			if (response.Contains("ERR"))
+			{
+				this.LogWarning("ProcessResponse: Device error - {response}", response);
+				return;
+			}
+			
 			if (!response.Contains("!")) return;
 
 			this.LogVerbose("ProcessResponse: {response}", response);
@@ -929,7 +937,8 @@ namespace ChristieProjectorPlugin
 		/// </summary>
 		public void VideoMuteGet()
 		{
-			SendText("SHU", "?");
+			// SHU command is disabled on this device
+			return;
 		}
 
 		/// <summary>
@@ -937,10 +946,8 @@ namespace ChristieProjectorPlugin
 		/// </summary>
 		public void VideoMuteOn()
 		{
-			SendText("SHU", 1);
-
-			Thread.Sleep(25);
-			VideoMuteGet();
+			// SHU command is disabled on this device
+			return;
 		}
 
 		/// <summary>
@@ -948,10 +955,8 @@ namespace ChristieProjectorPlugin
 		/// </summary>
 		public void VideoMuteOff()
 		{
-			SendText("SHU", 0);
-
-			Thread.Sleep(25);
-			VideoMuteGet();
+			// SHU command is disabled on this device
+			return;
 		}
 
 		/// <summary>

--- a/src/Christie4K7HsController.cs
+++ b/src/Christie4K7HsController.cs
@@ -260,14 +260,6 @@ namespace ChristieProjectorPlugin
 		private void ProcessResponse(string response)
 		{
 			if (string.IsNullOrEmpty(response)) return;
-			
-			// Handle error responses
-			if (response.Contains("ERR"))
-			{
-				this.LogWarning("ProcessResponse: Device error - {response}", response);
-				return;
-			}
-			
 			if (!response.Contains("!")) return;
 
 			this.LogVerbose("ProcessResponse: {response}", response);
@@ -937,8 +929,7 @@ namespace ChristieProjectorPlugin
 		/// </summary>
 		public void VideoMuteGet()
 		{
-			// SHU command is disabled on this device
-			return;
+			SendText("SHU", "?");
 		}
 
 		/// <summary>
@@ -946,8 +937,10 @@ namespace ChristieProjectorPlugin
 		/// </summary>
 		public void VideoMuteOn()
 		{
-			// SHU command is disabled on this device
-			return;
+			SendText("SHU", 1);
+
+			Thread.Sleep(25);
+			VideoMuteGet();
 		}
 
 		/// <summary>
@@ -955,8 +948,10 @@ namespace ChristieProjectorPlugin
 		/// </summary>
 		public void VideoMuteOff()
 		{
-			// SHU command is disabled on this device
-			return;
+			SendText("SHU", 0);
+
+			Thread.Sleep(25);
+			VideoMuteGet();
 		}
 
 		/// <summary>

--- a/src/Christie4K7HsController.cs
+++ b/src/Christie4K7HsController.cs
@@ -292,20 +292,46 @@ namespace ChristieProjectorPlugin
 			{
 				case "PWR":
 				{
-					bool newPowerState = responseValue == 1;
-					PowerIsOn = newPowerState;
+					// responseValue: 0=OFF, 1=ON, 10=cooling, 11=warming
 					
-					// Clear warming/cooling flags when we get the actual power feedback
-					if (newPowerState && IsWarmingUp)
+					// Device is warming up
+					if (responseValue == 11)
 					{
-						IsWarmingUp = false; // Got power on feedback, clear warming
-						//this.LogVerbose("ProcessResponse: Received PWR!1 feedback, clearing IsWarmingUp");
+						IsWarmingUp = true;
+						this.LogVerbose("ProcessResponse: Device warming (PWR!11)");
 					}
-					else if (!newPowerState && IsCoolingDown)
+					// Device is cooling down
+					else if (responseValue == 10)
 					{
-						IsCoolingDown = false; // Got power off feedback, clear cooling
-						//this.LogVerbose("ProcessResponse: Received PWR!0 feedback, clearing IsCoolingDown");
+						IsCoolingDown = true;
+						this.LogVerbose("ProcessResponse: Device cooling (PWR!10)");
 					}
+					// Warmup CONFIRMED (PWR!01)
+					else if (responseValue == 1)
+					{
+						IsWarmingUp = false;
+						this.LogWarning("ProcessResponse: Warmup confirmed (PWR!01). Checking pending commands.");
+						if (_pendingPowerOff)
+						{
+							_pendingPowerOff = false;
+							this.LogWarning("ProcessResponse: Executing pending PowerOff");
+							PowerOff();
+						}
+					}
+					// Cooldown CONFIRMED (PWR!00)
+					else if (responseValue == 0)
+					{
+						IsCoolingDown = false;
+						this.LogWarning("ProcessResponse: Cooldown confirmed (PWR!00). Checking pending commands.");
+						if (_pendingPowerOn)
+						{
+							_pendingPowerOn = false;
+							this.LogWarning("ProcessResponse: Executing pending PowerOn");
+							PowerOn();
+						}
+					}
+					
+					PowerIsOn = (responseValue == 1);
 					break;
 				}
 				case "ILI":
@@ -435,13 +461,6 @@ namespace ChristieProjectorPlugin
 			while (_commandQueue.Count > 0)
 			{
 				string text = _commandQueue.Peek();
-				
-				// Block control commands if warming or cooling
-				if (IsWarmingUp || IsCoolingDown)
-				{
-					this.LogVerbose("ProcessCommandQueue: Device warming={IsWarmingUp} or cooling={IsCoolingDown}. Queue held.", IsWarmingUp, IsCoolingDown);
-					return;
-				}
 
 				try
 				{
@@ -638,13 +657,20 @@ namespace ChristieProjectorPlugin
 		/// </summary>
 		public override void PowerOn()
 		{
-			if (IsWarmingUp || IsCoolingDown) return;
+			// Skip if already warming up
+			if (IsWarmingUp) return;
+
+			// Queue power on if cooling down
+			if (IsCoolingDown)
+			{
+				_pendingPowerOn = true;
+				this.LogWarning("PowerOn: Queued (cooling down)");
+				return;
+			}
 
 			if (PowerIsOn == false) IsWarmingUp = true;
 
 			SendText("PWR", 1);
-
-			Thread.Sleep(1500);
 
 			PowerGet();
 
@@ -655,14 +681,20 @@ namespace ChristieProjectorPlugin
 		/// </summary>
 		public override void PowerOff()
 		{
-			if (IsWarmingUp || IsCoolingDown) return;
+			// Skip if already cooling down
+			if (IsCoolingDown) return;
+
+			// Queue power off if warming up
+			if (IsWarmingUp)
+			{
+				_pendingPowerOff = true;
+				this.LogWarning("PowerOff: Queued (warming up)");
+				return;
+			}
 
 			if (PowerIsOn == true) IsCoolingDown = true;
 
 			SendText("PWR", 0);
-
-
-			Thread.Sleep(50);
 
 			PowerGet();
 
@@ -1056,6 +1088,13 @@ namespace ChristieProjectorPlugin
 		{
 			SendText("ILI", "?");
 		}
+
+		#endregion
+
+		#region Power State Management
+
+		private bool _pendingPowerOn;
+		private bool _pendingPowerOff;
 
 		#endregion
 

--- a/src/Christie4K7HsController.cs
+++ b/src/Christie4K7HsController.cs
@@ -61,7 +61,7 @@ namespace ChristieProjectorPlugin
 
 			_isSerialComm = !(Communication is ISocketStatus socket);
 
-			var pollIntervalMs = props.PollIntervalMs > 45000 ? props.PollIntervalMs : 45000;
+			var pollIntervalMs = props.PollIntervalMs >= 10000 ? props.PollIntervalMs : 10000;
 			CommunicationMonitor = new GenericCommunicationMonitor(this, Communication, pollIntervalMs, 180000, 300000,
 				StatusGet);
 
@@ -291,10 +291,23 @@ namespace ChristieProjectorPlugin
 			switch (responseType)
 			{
 				case "PWR":
+				{
+					bool newPowerState = responseValue == 1;
+					PowerIsOn = newPowerState;
+					
+					// Clear warming/cooling flags when we get the actual power feedback
+					if (newPowerState && IsWarmingUp)
 					{
-						PowerIsOn = responseValue == 1;
-						break;
+						IsWarmingUp = false; // Got power on feedback, clear warming
+						this.LogVerbose("ProcessResponse: Received PWR!1 feedback, clearing IsWarmingUp");
 					}
+					else if (!newPowerState && IsCoolingDown)
+					{
+						IsCoolingDown = false; // Got power off feedback, clear cooling
+						this.LogVerbose("ProcessResponse: Received PWR!0 feedback, clearing IsCoolingDown");
+					}
+					break;
+				}
 				case "ILI":
 					{
 						// TODO [ ] Verify feedback with actual device, not in api doc
@@ -350,7 +363,8 @@ namespace ChristieProjectorPlugin
 
 		/// <summary>
 		/// Queues a formatted command for sending with state checking and throttling.
-		/// Commands are held if device is warming up or cooling down, then sent when ready.
+		/// Control commands trigger warming/cooling flags based on the command type.
+		/// Query commands (containing ?) are sent immediately without queuing.
 		/// </summary>
 		private void SendCommandQueued(string text)
 		{
@@ -362,11 +376,49 @@ namespace ChristieProjectorPlugin
 				return;
 			}
 
+			// Query commands (containing ?) bypass queue and send immediately
+			if (text.Contains("?"))
+			{
+				lock (_sendLock)
+				{
+					try
+					{
+						Communication.SendText(text);
+						this.LogVerbose("SendCommandQueued: Query sent immediately: {text}", text);
+					}
+					catch (Exception ex)
+					{
+						this.LogError(ex, "Exception sending query command");
+					}
+				}
+				return;
+			}
+
 			lock (_sendLock)
 			{
+				// Check if this is a power control command (not a query)
+				// PWR!1 = power on -> expect warming
+				// PWR!0 = power off -> expect cooling
+				if (text.Contains("(PWR!1)"))
+				{
+					if (!IsWarmingUp)
+					{
+						IsWarmingUp = true;
+						this.LogVerbose("SendCommandQueued: Power ON command queued, setting IsWarmingUp=true. Warming time: {WarmupTimeMs}ms", WarmupTime);
+					}
+				}
+				else if (text.Contains("(PWR!0)"))
+				{
+					if (!IsCoolingDown)
+					{
+						IsCoolingDown = true;
+						this.LogVerbose("SendCommandQueued: Power OFF command queued, setting IsCoolingDown=true. Cooling time: {CooldownTimeMs}ms", CooldownTime);
+					}
+				}
+
 				// Queue the command
 				_commandQueue.Enqueue(text);
-				this.LogVerbose("SendCommandQueued: Command queued: {text}. Queue size: {queueSize}", text, _commandQueue.Count);
+				this.LogVerbose("SendCommandQueued: Control command queued: {text}. Queue size: {queueSize}", text, _commandQueue.Count);
 				
 				// Try to process queue
 				ProcessCommandQueue();
@@ -375,27 +427,28 @@ namespace ChristieProjectorPlugin
 
 		/// <summary>
 		/// Processes the command queue, sending commands only when device is ready.
+		/// Only control commands are in queue; queries are sent immediately bypassing queue.
 		/// Commands are held if device is warming or cooling.
 		/// </summary>
 		private void ProcessCommandQueue()
 		{
-			// Don't send if device is warming or cooling
-			if (IsWarmingUp || IsCoolingDown)
-			{
-				this.LogVerbose("ProcessCommandQueue: Device warming={IsWarmingUp} or cooling={IsCoolingDown}. Queue held.", IsWarmingUp, IsCoolingDown);
-				return;
-			}
-
 			while (_commandQueue.Count > 0)
 			{
+				string text = _commandQueue.Peek();
+				
+				// Block control commands if warming or cooling
+				if (IsWarmingUp || IsCoolingDown)
+				{
+					this.LogVerbose("ProcessCommandQueue: Device warming={IsWarmingUp} or cooling={IsCoolingDown}. Queue held.", IsWarmingUp, IsCoolingDown);
+					return;
+				}
+
 				try
 				{
-					string text = _commandQueue.Peek();
-
 					// Calculate time to wait based on minimum send interval
 					long currentTimeMs = Convert.ToInt64(DateTime.Now.ToUniversalTime().Subtract(new DateTime(1970, 1, 1, 0, 0, 0, DateTimeKind.Utc)).TotalMilliseconds);
 					long timeSinceLastSendMs = currentTimeMs - _lastSendTimeMs;
-
+					
 					if (timeSinceLastSendMs < MinSendIntervalMs)
 					{
 						long delayMs = MinSendIntervalMs - timeSinceLastSendMs;

--- a/src/Christie4K7HsController.cs
+++ b/src/Christie4K7HsController.cs
@@ -82,7 +82,7 @@ namespace ChristieProjectorPlugin
 		}
 
 
-		/// <summary>
+		/// <summary> ///
 		/// Initializes the device by establishing communication connection and starting the communication monitor
 		/// </summary>
 		public override void Initialize()

--- a/src/Christie4K7HsController.cs
+++ b/src/Christie4K7HsController.cs
@@ -234,6 +234,10 @@ namespace ChristieProjectorPlugin
 		private const string GatherDelimiter = @"\)";
 
 		private readonly GenericQueue _receiveQueue;
+		private long _lastSendTimeMs = 0;
+		private const int MinSendIntervalMs = 100; // Minimum milliseconds between sends
+		private readonly object _sendLock = new object();
+		private readonly Queue<string> _commandQueue = new Queue<string>();
 
 		private void OnCommunicationMonitorStatusChange(object sender, MonitorStatusChangeEventArgs args)
 		{
@@ -324,15 +328,8 @@ namespace ChristieProjectorPlugin
 		{
 			if (string.IsNullOrEmpty(cmd)) return;
 
-			if (!Communication.IsConnected)
-			{
-				this.LogWarning("SendText: device not connected");
-				return;
-			}
-
 			var text = string.Format("({0})", cmd);
-
-			Communication.SendText(text);
+			SendCommandQueued(text);
 		}
 
 		// formats outgoing message
@@ -341,14 +338,83 @@ namespace ChristieProjectorPlugin
 			var text = string.IsNullOrEmpty(value)
 				? "?"
 				: string.Format("({0}{1})", cmd, value);
-			Communication.SendText(text);
+			SendCommandQueued(text);
 		}
 
 		// formats outgoing message
 		private void SendText(string cmd, int value)
 		{
 			// tx format: "({cmd}{value})"
-			Communication.SendText(string.Format("({0}{1})", cmd, value));
+			SendCommandQueued(string.Format("({0}{1})", cmd, value));
+		}
+
+		/// <summary>
+		/// Queues a formatted command for sending with state checking and throttling.
+		/// Commands are held if device is warming up or cooling down, then sent when ready.
+		/// </summary>
+		private void SendCommandQueued(string text)
+		{
+			if (string.IsNullOrEmpty(text)) return;
+
+			if (!Communication.IsConnected)
+			{
+				this.LogWarning("SendCommandQueued: device not connected");
+				return;
+			}
+
+			lock (_sendLock)
+			{
+				// Queue the command
+				_commandQueue.Enqueue(text);
+				this.LogVerbose("SendCommandQueued: Command queued: {text}. Queue size: {queueSize}", text, _commandQueue.Count);
+				
+				// Try to process queue
+				ProcessCommandQueue();
+			}
+		}
+
+		/// <summary>
+		/// Processes the command queue, sending commands only when device is ready.
+		/// Commands are held if device is warming or cooling.
+		/// </summary>
+		private void ProcessCommandQueue()
+		{
+			// Don't send if device is warming or cooling
+			if (IsWarmingUp || IsCoolingDown)
+			{
+				this.LogVerbose("ProcessCommandQueue: Device warming={IsWarmingUp} or cooling={IsCoolingDown}. Queue held.", IsWarmingUp, IsCoolingDown);
+				return;
+			}
+
+			while (_commandQueue.Count > 0)
+			{
+				try
+				{
+					string text = _commandQueue.Peek();
+
+					// Calculate time to wait based on minimum send interval
+					long currentTimeMs = Convert.ToInt64(DateTime.Now.ToUniversalTime().Subtract(new DateTime(1970, 1, 1, 0, 0, 0, DateTimeKind.Utc)).TotalMilliseconds);
+					long timeSinceLastSendMs = currentTimeMs - _lastSendTimeMs;
+
+					if (timeSinceLastSendMs < MinSendIntervalMs)
+					{
+						long delayMs = MinSendIntervalMs - timeSinceLastSendMs;
+						this.LogVerbose("ProcessCommandQueue: Throttling for {delayMs}ms", delayMs);
+						Thread.Sleep((int)delayMs);
+					}
+
+					// Send the command
+					Communication.SendText(text);
+					_lastSendTimeMs = Convert.ToInt64(DateTime.Now.ToUniversalTime().Subtract(new DateTime(1970, 1, 1, 0, 0, 0, DateTimeKind.Utc)).TotalMilliseconds);
+					_commandQueue.Dequeue(); // Remove from queue after successful send
+					this.LogVerbose("ProcessCommandQueue: Sent {text}. Remaining in queue: {queueSize}", text, _commandQueue.Count);
+				}
+				catch (Exception ex)
+				{
+					this.LogError(ex, "Exception in ProcessCommandQueue");
+					break; // Stop processing if there's an error
+				}
+			}
 		}
 
 		/// <summary>
@@ -446,7 +512,20 @@ namespace ChristieProjectorPlugin
 					{
 						_isWarmingUp = false;
 						IsWarmingUpFeedback.FireUpdate();
+						// Process any queued commands now that warmup is complete
+						lock (_sendLock)
+						{
+							ProcessCommandQueue();
+						}
 					}, WarmupTime);
+				}
+				else
+				{
+					// Warmup completed, process queued commands
+					lock (_sendLock)
+					{
+						ProcessCommandQueue();
+					}
 				}
 			}
 		}
@@ -468,7 +547,20 @@ namespace ChristieProjectorPlugin
 					{
 						_isCoolingDown = false;
 						IsCoolingDownFeedback.FireUpdate();
+						// Process any queued commands now that cooldown is complete
+						lock (_sendLock)
+						{
+							ProcessCommandQueue();
+						}
 					}, CooldownTime);
+				}
+				else
+				{
+					// Cooldown completed, process queued commands
+					lock (_sendLock)
+					{
+						ProcessCommandQueue();
+					}
 				}
 			}
 		}

--- a/src/Christie4K7HsController.cs
+++ b/src/Christie4K7HsController.cs
@@ -248,7 +248,7 @@ namespace ChristieProjectorPlugin
 		{
 			try
 			{
-				this.LogVerbose("OnCommunicationGatherLineReceived: args.Text-'{0}'", args.Text);
+				//this.LogVerbose("OnCommunicationGatherLineReceived: args.Text-'{0}'", args.Text);
 				_receiveQueue.Enqueue(new ProcessStringMessage(args.Text, ProcessResponse));
 			}
 			catch (Exception ex)
@@ -266,7 +266,7 @@ namespace ChristieProjectorPlugin
 			if (string.IsNullOrEmpty(response)) return;
 			if (!response.Contains("!")) return;
 
-			this.LogVerbose("ProcessResponse: {response}", response);
+			//this.LogVerbose("ProcessResponse: {response}", response);
 
 			var responseValue = 0;
 			var responseType = "";
@@ -286,7 +286,7 @@ namespace ChristieProjectorPlugin
 				this.LogError(ex, "ProcessResponse exception");
 			}
 
-			this.LogVerbose("ProcessResponse: responseType-{responseType}, responseValue-{responseValue}", responseType, responseValue);
+			//this.LogVerbose("ProcessResponse: responseType-{responseType}, responseValue-{responseValue}", responseType, responseValue);
 
 			switch (responseType)
 			{
@@ -299,12 +299,12 @@ namespace ChristieProjectorPlugin
 					if (newPowerState && IsWarmingUp)
 					{
 						IsWarmingUp = false; // Got power on feedback, clear warming
-						this.LogVerbose("ProcessResponse: Received PWR!1 feedback, clearing IsWarmingUp");
+						//this.LogVerbose("ProcessResponse: Received PWR!1 feedback, clearing IsWarmingUp");
 					}
 					else if (!newPowerState && IsCoolingDown)
 					{
 						IsCoolingDown = false; // Got power off feedback, clear cooling
-						this.LogVerbose("ProcessResponse: Received PWR!0 feedback, clearing IsCoolingDown");
+						//this.LogVerbose("ProcessResponse: Received PWR!0 feedback, clearing IsCoolingDown");
 					}
 					break;
 				}
@@ -327,7 +327,7 @@ namespace ChristieProjectorPlugin
 					}
 				default:
 					{
-						this.LogVerbose("ProcessResponse: unknown response {responseType}", responseType);
+						//this.LogVerbose("ProcessResponse: unknown response {responseType}", responseType);
 						break;
 					}
 			}

--- a/src/Christie4K7HsController.cs
+++ b/src/Christie4K7HsController.cs
@@ -920,7 +920,7 @@ namespace ChristieProjectorPlugin
 
 
 		/// <summary>
-		/// Gets or sets the feedback object for video mute state
+		/// Gets the feedback object for video mute state
 		/// </summary>
 		public BoolFeedback VideoMuteIsOn { get; private set; }
 


### PR DESCRIPTION
This pull request introduces significant improvements to the `Christie4K25RgbController` class, primarily focusing on robust command queuing, reliable power state management, and improved feedback mechanisms. It also includes a new VSCode build task. The main changes are grouped below:

### Power State and Command Management Improvements

* Added a command queue with throttling and state checks to ensure that control commands (such as power on/off) are sent only when the projector is ready, preventing command loss or device lockup during warmup/cooldown. Query commands bypass the queue for immediate execution. (`src/Christie4K25RgbController.cs`) [[1]](diffhunk://#diff-433fed0e5fcd06056929bd6538e8a9079fe636c4f278644e53487391b0913568R239-R242) [[2]](diffhunk://#diff-433fed0e5fcd06056929bd6538e8a9079fe636c4f278644e53487391b0913568L354-R503)
* Implemented pending power on/off flags to queue power commands when the device is in an intermediate state (warming up or cooling down), and execute them once the device is ready. (`src/Christie4K25RgbController.cs`) [[1]](diffhunk://#diff-433fed0e5fcd06056929bd6538e8a9079fe636c4f278644e53487391b0913568L303-R349) [[2]](diffhunk://#diff-433fed0e5fcd06056929bd6538e8a9079fe636c4f278644e53487391b0913568L506-L513) [[3]](diffhunk://#diff-433fed0e5fcd06056929bd6538e8a9079fe636c4f278644e53487391b0913568L523-R713) [[4]](diffhunk://#diff-433fed0e5fcd06056929bd6538e8a9079fe636c4f278644e53487391b0913568L1015-R1203)
* Updated the logic in `PowerOn()` and `PowerOff()` to utilize the new queuing mechanism, improving reliability during state transitions. (`src/Christie4K25RgbController.cs`) [[1]](diffhunk://#diff-433fed0e5fcd06056929bd6538e8a9079fe636c4f278644e53487391b0913568L506-L513) [[2]](diffhunk://#diff-433fed0e5fcd06056929bd6538e8a9079fe636c4f278644e53487391b0913568L523-R713)

### Video Mute Feedback Refactor

* Changed from a simple boolean property to a `BoolFeedback` object for video mute state, ensuring correct feedback propagation and integration with the control system. (`src/Christie4K25RgbController.cs`) [[1]](diffhunk://#diff-433fed0e5fcd06056929bd6538e8a9079fe636c4f278644e53487391b0913568L24-R24) [[2]](diffhunk://#diff-433fed0e5fcd06056929bd6538e8a9079fe636c4f278644e53487391b0913568L63-L74) [[3]](diffhunk://#diff-433fed0e5fcd06056929bd6538e8a9079fe636c4f278644e53487391b0913568L183-R185) [[4]](diffhunk://#diff-433fed0e5fcd06056929bd6538e8a9079fe636c4f278644e53487391b0913568L318-R365) [[5]](diffhunk://#diff-433fed0e5fcd06056929bd6538e8a9079fe636c4f278644e53487391b0913568L1015-R1203)

### Code Quality and Performance

* Removed unnecessary `Thread.Sleep` calls from input selection and status methods, improving responsiveness and reducing blocking. (`src/Christie4K25RgbController.cs`) [[1]](diffhunk://#diff-433fed0e5fcd06056929bd6538e8a9079fe636c4f278644e53487391b0913568L405-L410) [[2]](diffhunk://#diff-433fed0e5fcd06056929bd6538e8a9079fe636c4f278644e53487391b0913568L763) [[3]](diffhunk://#diff-433fed0e5fcd06056929bd6538e8a9079fe636c4f278644e53487391b0913568L773) [[4]](diffhunk://#diff-433fed0e5fcd06056929bd6538e8a9079fe636c4f278644e53487391b0913568L783) [[5]](diffhunk://#diff-433fed0e5fcd06056929bd6538e8a9079fe636c4f278644e53487391b0913568L794) [[6]](diffhunk://#diff-433fed0e5fcd06056929bd6538e8a9079fe636c4f278644e53487391b0913568L804) [[7]](diffhunk://#diff-433fed0e5fcd06056929bd6538e8a9079fe636c4f278644e53487391b0913568L814-L815) [[8]](diffhunk://#diff-433fed0e5fcd06056929bd6538e8a9079fe636c4f278644e53487391b0913568L825-L826) [[9]](diffhunk://#diff-433fed0e5fcd06056929bd6538e8a9079fe636c4f278644e53487391b0913568L836-L837) [[10]](diffhunk://#diff-433fed0e5fcd06056929bd6538e8a9079fe636c4f278644e53487391b0913568L847-L848) [[11]](diffhunk://#diff-433fed0e5fcd06056929bd6538e8a9079fe636c4f278644e53487391b0913568L859-L860) [[12]](diffhunk://#diff-433fed0e5fcd06056929bd6538e8a9079fe636c4f278644e53487391b0913568L871-L872)
* Improved logging for debugging and removed excessive verbose logs from response processing. (`src/Christie4K25RgbController.cs`) [[1]](diffhunk://#diff-433fed0e5fcd06056929bd6538e8a9079fe636c4f278644e53487391b0913568L248-R253) [[2]](diffhunk://#diff-433fed0e5fcd06056929bd6538e8a9079fe636c4f278644e53487391b0913568L288-R293) [[3]](diffhunk://#diff-433fed0e5fcd06056929bd6538e8a9079fe636c4f278644e53487391b0913568L318-R365)

### Development Environment

* Added a VSCode build task for the Christie Projector solution to streamline development. (`.vscode/tasks.json`)