### PR TITLE
Feature/inputs to use friendly names - Tested onsite

### DIFF
--- a/src/Christie4K25RgbController.cs
+++ b/src/Christie4K25RgbController.cs
@@ -1116,37 +1116,37 @@ namespace ChristieProjectorPlugin
 
 			switch (CurrentInputPort.Key)
 			{
-				case "HDMI 1":
+				case RoutingPortNames.HdmiIn1:
 					CurrentInputNumber = 1;
 					break;
-				case "HDMI 2":
+				case RoutingPortNames.HdmiIn2:
 					CurrentInputNumber = 2;
 					break;
-				case "HDBaseT":
+				case RoutingPortNames.HdmiIn3:
 					CurrentInputNumber = 3;
 					break;
-				case "Display Port 1":
+				case RoutingPortNames.DisplayPortIn1:
 					CurrentInputNumber = 4;
 					break;
-				case "Display Port 2":
+				case RoutingPortNames.DisplayPortIn2:
 					CurrentInputNumber = 5;
 					break;
-				case "SDI 1":
+				case RoutingPortNames.RgbIn1:
 					CurrentInputNumber = 6;
 					break;
-				case "SDI 2":
+				case RoutingPortNames.RgbIn2:
 					CurrentInputNumber = 7;
 					break;
-				case "SDI 3":
+				case RoutingPortNames.VgaIn1:
 					CurrentInputNumber = 8;
 					break;
-				case "SDI 4":
+				case RoutingPortNames.HdmiIn4:
 					CurrentInputNumber = 9;
 					break;
-				case "Digital Link 1":
+				case "link1":
 					CurrentInputNumber = 10;
 					break;
-				case "Digital Link 2":
+				case "link2":
 					CurrentInputNumber = 11;
 					break;
 			}

--- a/src/Christie4K25RgbController.cs
+++ b/src/Christie4K25RgbController.cs
@@ -958,7 +958,7 @@ namespace ChristieProjectorPlugin
 
 			Inputs = new ChristieProjectorInputs()
 			{
-				Items = InputPorts.ToDictionary(p => p.Key, p => new ChristieProjectorInput(p.Key, p.Key, p.Selector as Action) as ISelectableItem)
+				Items = InputPorts.ToDictionary(p => p.Key, p => new ChristieProjectorInput(p.Key, GetInputNameForKey(p.Key), p.Selector as Action) as ISelectableItem)
 			};
 		}
 

--- a/src/Christie4K25RgbController.cs
+++ b/src/Christie4K25RgbController.cs
@@ -864,9 +864,9 @@ namespace ChristieProjectorPlugin
 				case "hdmiIn3":
 					return "HDBaseT";
 				case "displayPortIn1":
-					return "Display Port 1";
+					return "DisplayPort 1";
 				case "displayPortIn2":
-					return "Display Port 2";
+					return "DisplayPort 2";
 				case "rgbIn1":
 					return "SDI 1";
 				case "rgbIn2":
@@ -875,12 +875,10 @@ namespace ChristieProjectorPlugin
 					return "SDI 3";
 				case "hdmiIn4":
 					return "SDI 4";
-				case "hdmiIn5":
+				case "link1":
 					return "Digital Link 1";
-				case "hdmiIn6":
+				case "link2":
 					return "Digital Link 2";
-
-
 				default:
 					return string.Empty;
 			}
@@ -908,11 +906,11 @@ namespace ChristieProjectorPlugin
 
 			AddRoutingInputPort(
 					new RoutingInputPort(RoutingPortNames.DisplayPortIn1, eRoutingSignalType.Audio | eRoutingSignalType.Video,
-							eRoutingPortConnectionType.DisplayPort, new Action(InputDisplayPort1), this), 4);
+						eRoutingPortConnectionType.DisplayPort, new Action(InputDisplayPort1), this), 4);
 
 			AddRoutingInputPort(
 					new RoutingInputPort(RoutingPortNames.DisplayPortIn2, eRoutingSignalType.Audio | eRoutingSignalType.Video,
-							eRoutingPortConnectionType.DisplayPort, new Action(InputDisplayPort2), this), 5);
+						eRoutingPortConnectionType.DisplayPort, new Action(InputDisplayPort2), this), 5);
 
 			AddRoutingInputPort(
 				new RoutingInputPort(RoutingPortNames.RgbIn1, eRoutingSignalType.Audio | eRoutingSignalType.Video,
@@ -920,15 +918,15 @@ namespace ChristieProjectorPlugin
 
 			AddRoutingInputPort(
 					new RoutingInputPort(RoutingPortNames.RgbIn2, eRoutingSignalType.Audio | eRoutingSignalType.Video,
-							eRoutingPortConnectionType.Sdi, new Action(InputSdi2), this), 7);
+						eRoutingPortConnectionType.Sdi, new Action(InputSdi2), this), 7);
 
 			AddRoutingInputPort(
 					new RoutingInputPort(RoutingPortNames.VgaIn1, eRoutingSignalType.Audio | eRoutingSignalType.Video,
-							eRoutingPortConnectionType.Sdi, new Action(InputSdi3), this), 8);
+						eRoutingPortConnectionType.Sdi, new Action(InputSdi3), this), 8);
 
 			AddRoutingInputPort(
 					new RoutingInputPort(RoutingPortNames.HdmiIn4, eRoutingSignalType.Audio | eRoutingSignalType.Video,
-							eRoutingPortConnectionType.Sdi, new Action(InputSdi4), this), 9);
+						eRoutingPortConnectionType.Sdi, new Action(InputSdi4), this), 9);
 
 
 			AddRoutingInputPort(
@@ -1118,37 +1116,37 @@ namespace ChristieProjectorPlugin
 
 			switch (CurrentInputPort.Key)
 			{
-				case RoutingPortNames.HdmiIn1:
+				case "HDMI 1":
 					CurrentInputNumber = 1;
 					break;
-				case RoutingPortNames.HdmiIn2:
+				case "HDMI 2":
 					CurrentInputNumber = 2;
 					break;
-				case RoutingPortNames.HdmiIn3:
+				case "HDBaseT":
 					CurrentInputNumber = 3;
 					break;
-				case RoutingPortNames.DisplayPortIn1:
+				case "Display Port 1":
 					CurrentInputNumber = 4;
 					break;
-				case RoutingPortNames.DisplayPortIn2:
+				case "Display Port 2":
 					CurrentInputNumber = 5;
 					break;
-				case RoutingPortNames.RgbIn1:
+				case "SDI 1":
 					CurrentInputNumber = 6;
 					break;
-				case RoutingPortNames.RgbIn2:
+				case "SDI 2":
 					CurrentInputNumber = 7;
 					break;
-				case RoutingPortNames.VgaIn1:
+				case "SDI 3":
 					CurrentInputNumber = 8;
 					break;
-				case RoutingPortNames.HdmiIn4:
+				case "SDI 4":
 					CurrentInputNumber = 9;
 					break;
-				case RoutingPortNames.HdmiIn5:
+				case "Digital Link 1":
 					CurrentInputNumber = 10;
 					break;
-				case RoutingPortNames.HdmiIn6:
+				case "Digital Link 2":
 					CurrentInputNumber = 11;
 					break;
 			}

--- a/src/Christie4K35RgbController.cs
+++ b/src/Christie4K35RgbController.cs
@@ -653,14 +653,14 @@ namespace ChristieProjectorPlugin
 					return "HDMI 2";
 				case "hdmiIn3":
 					return "VOM HDMI 1";
-				case "displayPortIn1":
-					return "Display Port 1";
-				case "displayPortIn2":
-					return "Display Port 2";
 				case "displayPortIn3":
-					return "VOM Display Port 1";
+					return "VOM DisplayPort 1";
 				case "displayPortIn":
-					return "VOM Display Port 2";
+					return "VOM DisplayPort 2";
+				case "displayPortIn1":
+					return "DisplayPort 1";
+				case "displayPortIn2":
+					return "DisplayPort 2";
 				case "sdiIn":
 					return "SDI 1";
 				case "rgbIn":
@@ -671,10 +671,8 @@ namespace ChristieProjectorPlugin
 					return "SDI 4";
 				case "vgaIn1":
 					return "Digital Link 1";
-				case "vgaIn2":
+				case "vgaIn":
 					return "Digital Link 2";
-
-
 				default:
 					return string.Empty;
 			}
@@ -702,19 +700,19 @@ namespace ChristieProjectorPlugin
 
 			AddRoutingInputPort(
 					new RoutingInputPort(RoutingPortNames.DisplayPortIn3, eRoutingSignalType.Audio | eRoutingSignalType.Video,
-							eRoutingPortConnectionType.DisplayPort, new Action(InputVomDisplayPort1), this), 4);
+						eRoutingPortConnectionType.DisplayPort, new Action(InputVomDisplayPort1), this), 4);
 
 			AddRoutingInputPort(
 					new RoutingInputPort(RoutingPortNames.DisplayPortIn, eRoutingSignalType.Audio | eRoutingSignalType.Video,
-							eRoutingPortConnectionType.DisplayPort, new Action(InputVomDisplayPort2), this), 5);
+						eRoutingPortConnectionType.DisplayPort, new Action(InputVomDisplayPort2), this), 5);
 
 			AddRoutingInputPort(
 					new RoutingInputPort(RoutingPortNames.DisplayPortIn1, eRoutingSignalType.Audio | eRoutingSignalType.Video,
-							eRoutingPortConnectionType.DisplayPort, new Action(InputDisplayPort1), this), 6);
+						eRoutingPortConnectionType.DisplayPort, new Action(InputDisplayPort1), this), 6);
 
 			AddRoutingInputPort(
 					new RoutingInputPort(RoutingPortNames.DisplayPortIn2, eRoutingSignalType.Audio | eRoutingSignalType.Video,
-							eRoutingPortConnectionType.DisplayPort, new Action(InputDisplayPort2), this), 7);
+						eRoutingPortConnectionType.DisplayPort, new Action(InputDisplayPort2), this), 7);
 
 			AddRoutingInputPort(
 				new RoutingInputPort(RoutingPortNames.SdiIn, eRoutingSignalType.Audio | eRoutingSignalType.Video,
@@ -722,24 +720,23 @@ namespace ChristieProjectorPlugin
 
 			AddRoutingInputPort(
 					new RoutingInputPort(RoutingPortNames.RgbIn, eRoutingSignalType.Audio | eRoutingSignalType.Video,
-							eRoutingPortConnectionType.Sdi, new Action(InputSdi2), this), 9);
+						eRoutingPortConnectionType.Sdi, new Action(InputSdi2), this), 9);
 
 			AddRoutingInputPort(
 					new RoutingInputPort(RoutingPortNames.RgbIn1, eRoutingSignalType.Audio | eRoutingSignalType.Video,
-							eRoutingPortConnectionType.Sdi, new Action(InputSdi3), this), 10);
+						eRoutingPortConnectionType.Sdi, new Action(InputSdi3), this), 10);
 
 			AddRoutingInputPort(
 					new RoutingInputPort(RoutingPortNames.RgbIn2, eRoutingSignalType.Audio | eRoutingSignalType.Video,
-							eRoutingPortConnectionType.Sdi, new Action(InputSdi4), this), 11);
+						eRoutingPortConnectionType.Sdi, new Action(InputSdi4), this), 11);
 
 			AddRoutingInputPort(
 					new RoutingInputPort(RoutingPortNames.VgaIn1, eRoutingSignalType.Audio | eRoutingSignalType.Video,
-							eRoutingPortConnectionType.Streaming, new Action(InputDigitalLink1), this), 12);
+						eRoutingPortConnectionType.Streaming, new Action(InputDigitalLink1), this), 12);
 
 			AddRoutingInputPort(
 					new RoutingInputPort(RoutingPortNames.VgaIn, eRoutingSignalType.Audio | eRoutingSignalType.Video,
 							eRoutingPortConnectionType.Streaming, new Action(InputDigitalLink2), this), 13);
-
 
 			// initialize feedbacks after adding input ports
 			_inputFeedback = new List<bool>();

--- a/src/Christie4K35RgbController.cs
+++ b/src/Christie4K35RgbController.cs
@@ -758,7 +758,7 @@ namespace ChristieProjectorPlugin
 
 			Inputs = new ChristieProjectorInputs()
 			{
-				Items = InputPorts.ToDictionary(p => p.Key, p => new ChristieProjectorInput(p.Key, p.Key, p.Selector as Action) as ISelectableItem)
+				Items = InputPorts.ToDictionary(p => p.Key, p => new ChristieProjectorInput(p.Key, GetInputNameForKey(p.Key), p.Selector as Action) as ISelectableItem)
 			};
 		}
 

--- a/src/Christie4K7HsController.cs
+++ b/src/Christie4K7HsController.cs
@@ -1023,22 +1023,22 @@ namespace ChristieProjectorPlugin
 
 			switch (CurrentInputPort.Key)
 			{
-				case "HDMI 1":
+				case RoutingPortNames.HdmiIn1:
 					CurrentInputNumber = 1;
 					break;
-				case "HDMI 2":
+				case RoutingPortNames.HdmiIn2:
 					CurrentInputNumber = 2;
 					break;
-				case "DVI 1":
+				case RoutingPortNames.DviIn1:
 					CurrentInputNumber = 3;
 					break;
-				case "Display Port 1":
+				case RoutingPortNames.DisplayPortIn1:
 					CurrentInputNumber = 4;
 					break;
-				case "Slot 1":
+				case "slot1":
 					CurrentInputNumber = 5;
 					break;
-				case "Slot 2":
+				case "slot2":
 					CurrentInputNumber = 6;
 					break;
 			}

--- a/src/Christie4K7HsController.cs
+++ b/src/Christie4K7HsController.cs
@@ -820,10 +820,10 @@ namespace ChristieProjectorPlugin
 				case "dviIn1":
 					return "DVI 1";
 				case "displayPortIn1":
-					return "Display Port 1";
-				case "hdmiIn4":
+					return "DisplayPort 1";
+				case "slot1":
 					return "Slot 1";
-				case "hdmiIn5":
+				case "slot2":
 					return "Slot 2";
 				default:
 					return string.Empty;
@@ -1023,22 +1023,22 @@ namespace ChristieProjectorPlugin
 
 			switch (CurrentInputPort.Key)
 			{
-				case RoutingPortNames.HdmiIn1:
+				case "HDMI 1":
 					CurrentInputNumber = 1;
 					break;
-				case RoutingPortNames.HdmiIn2:
+				case "HDMI 2":
 					CurrentInputNumber = 2;
 					break;
-				case RoutingPortNames.DviIn1:
+				case "DVI 1":
 					CurrentInputNumber = 3;
 					break;
-				case RoutingPortNames.DisplayPortIn1:
+				case "Display Port 1":
 					CurrentInputNumber = 4;
 					break;
-				case "slot1":
+				case "Slot 1":
 					CurrentInputNumber = 5;
 					break;
-				case "slot2":
+				case "Slot 2":
 					CurrentInputNumber = 6;
 					break;
 			}

--- a/src/Christie4K7HsController.cs
+++ b/src/Christie4K7HsController.cs
@@ -882,7 +882,7 @@ namespace ChristieProjectorPlugin
 
 			Inputs = new ChristieProjectorInputs()
 			{
-				Items = InputPorts.ToDictionary(p => p.Key, p => new ChristieProjectorInput(p.Key, p.Key, p.Selector as Action) as ISelectableItem)
+				Items = InputPorts.ToDictionary(p => p.Key, p => new ChristieProjectorInput(p.Key, GetInputNameForKey(p.Key), p.Selector as Action) as ISelectableItem)
 			};
 		}
 


### PR DESCRIPTION
Bug Reported
Christie Projectors under displays tech section  list inputs pascal case

This pull request updates the input initialization and feedback logic across several Christie projector controller classes to improve input naming consistency and accuracy. The main changes involve using descriptive input names, updating input key mappings, and ensuring that the displayed names for inputs are accurate and user-friendly.

**Input naming consistency and mapping updates:**

* Updated the `GetInputNameForKey` method in all three controller classes (`Christie4K25RgbController`, `Christie4K35RgbController`, `Christie4K7HsController`) to return more descriptive and accurate input names for each input key, and adjusted key mappings to match the correct physical inputs. [[1]](diffhunk://#diff-433fed0e5fcd06056929bd6538e8a9079fe636c4f278644e53487391b0913568L878-L883) [[2]](diffhunk://#diff-7ab46c25ad1acfc9bd1ab42a83f1bbafcfd1be5fd4577bb9b31adf54630d301dL656-R663) [[3]](diffhunk://#diff-7ab46c25ad1acfc9bd1ab42a83f1bbafcfd1be5fd4577bb9b31adf54630d301dL674-L677) [[4]](diffhunk://#diff-ca82a5a113d819ee3ee93656bee9e181dd64a9529cf27f6f22be387532acbea3L824-R826)

* Changed the initialization of `Inputs` so that each input uses the descriptive name from `GetInputNameForKey` instead of the raw key, improving the UI and user experience. [[1]](diffhunk://#diff-433fed0e5fcd06056929bd6538e8a9079fe636c4f278644e53487391b0913568L963-R961) [[2]](diffhunk://#diff-7ab46c25ad1acfc9bd1ab42a83f1bbafcfd1be5fd4577bb9b31adf54630d301dL764-R761) [[3]](diffhunk://#diff-ca82a5a113d819ee3ee93656bee9e181dd64a9529cf27f6f22be387532acbea3L885-R885)

**Input feedback logic improvements:**

* Updated the `UpdateInputFb` methods to switch on the new descriptive input names rather than the old routing port constants, ensuring that feedback is correctly mapped to the new input names. [[1]](diffhunk://#diff-433fed0e5fcd06056929bd6538e8a9079fe636c4f278644e53487391b0913568L1121-R1149) [[2]](diffhunk://#diff-ca82a5a113d819ee3ee93656bee9e181dd64a9529cf27f6f22be387532acbea3L1026-R1041)

**Minor cleanup:**

* Removed redundant blank lines in the `Christie4K35RgbController` input initialization for clarity.